### PR TITLE
Add support for message in Firebase provider

### DIFF
--- a/lib/travis/yaml/spec/def/deploy/firebase.rb
+++ b/lib/travis/yaml/spec/def/deploy/firebase.rb
@@ -9,6 +9,7 @@ module Travis
             def define
               super
               map :project,  to: :str
+              map :message,  to: :str
               map :token,    to: :str, secure: true
             end
           end


### PR DESCRIPTION
Adds support for adding optional messages when deploying with the Firebase provider.

See travis-ci/dpl#651 for main PR.

Fixes travis-ci/travis-ci#7872