### PR TITLE
Do not raise when passed an empty string

### DIFF
--- a/lib/travis/yaml.rb
+++ b/lib/travis/yaml.rb
@@ -54,7 +54,7 @@ module Travis
       include Helper::Deyaml
 
       def load(yaml, opts = {})
-        hash = YAML.load(yaml, raise_on_unknown_tag: true)
+        hash = YAML.load(yaml.strip, raise_on_unknown_tag: true) || {}
         apply(hash, opts)
       end
 

--- a/spec/travis/yaml_spec.rb
+++ b/spec/travis/yaml_spec.rb
@@ -9,6 +9,13 @@ describe Travis::Yaml do
     end
   end
 
+  describe 'load' do
+    describe 'when passed \n' do
+      let(:config) { Travis::Yaml.load("\n") }
+      it { expect { config }.to_not raise_error }
+    end
+  end
+
   describe 'expanded' do
     let(:spec) { Travis::Yaml.expanded }
 


### PR DESCRIPTION
So far `Travis::Yaml.load("\n")` would raise an `ArgumentError` saying `input must be a Hash`.

