### PR TITLE
Handle deprecation key properly

### DIFF
--- a/lib/travis/yaml.rb
+++ b/lib/travis/yaml.rb
@@ -26,7 +26,7 @@ module Travis
       alias:           '%{alias} is an alias for %{actual}, using %{actual}',
       cast:            'casting value %{given_value} (%{given_type}) to %{value} (%{type})',
       default:         'missing %{key}, defaulting to: %{default}',
-      deprecated:      '%{key} is deprecated',
+      deprecated:      '%{given} is deprecated',
       downcase:        'downcasing %{value}',
       edge:            '%{given} is experimental and might be removed in the future',
       flagged:         'your repository must be feature flagged for %{given} to be used',

--- a/lib/travis/yaml/web/v1/parse.rb
+++ b/lib/travis/yaml/web/v1/parse.rb
@@ -18,7 +18,7 @@ module Travis::Yaml::Web
         [200, headers, body(Decorators::Config, config)]
       rescue Travis::Yaml::InputError, Psych::SyntaxError => error
         [400, headers, body(Decorators::Error, error)]
-      rescue Travis::Yaml::InternalError => error
+      rescue Travis::Yaml::InternalError, KeyError => error
         [500, headers, body(Decorators::Error, error)]
       end
     end

--- a/spec/travis/yaml_spec.rb
+++ b/spec/travis/yaml_spec.rb
@@ -65,7 +65,7 @@ describe Travis::Yaml do
     end
 
     describe 'deprecated' do
-      let(:msg) { [:info, :key, :deprecated, key: :key, info: 'something'] }
+      let(:msg) { [:info, :key, :deprecated, given: :key, info: 'something'] }
       it { should eq '[info] on key: :key is deprecated' }
     end
 


### PR DESCRIPTION
Also rescue KeyError in the parse endpoint, so we can see why
requests fail.