### PR TITLE
Remove version key from expanded matrix

### DIFF
--- a/lib/travis/yaml/matrix.rb
+++ b/lib/travis/yaml/matrix.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/hash/except'
 require 'travis/yaml/support/obj'
 
 module Travis
@@ -13,6 +14,7 @@ module Travis
         rows = with_global_env(rows)
         rows = with_shared(rows)
         rows = with_os(rows)
+        rows = cleaned(rows)
         rows = uniq(rows)
         rows
       end
@@ -97,6 +99,10 @@ module Travis
 
         def shared
           @shared ||= config.reject { |key, value| key == :matrix || keys.include?(key) || [[], nil].include?(value) }
+        end
+
+        def cleaned(rows)
+          rows.map { |row| row.except(:version) }
         end
 
         def uniq(rows)

--- a/spec/travis/yaml/matrix_spec.rb
+++ b/spec/travis/yaml/matrix_spec.rb
@@ -297,4 +297,18 @@ describe Travis::Yaml, 'matrix' do
 
     it { expect(matrix.rows).to eq rows }
   end
+
+  describe 'removes version' do
+    let(:input) do
+      { version: '= 0', language: 'shell' }
+    end
+
+    let(:rows) do
+      [
+        { language: 'shell' }
+      ]
+    end
+
+    it { expect(matrix.rows).to eq rows }
+  end
 end


### PR DESCRIPTION
Seems logical to me to leave it in the main config, but it has no
semantic meaning for job-level config and looks surprising in that
context.

See https://github.com/travis-ci/travis-gatekeeper/pull/275