### PR TITLE
Sort messages by severity

### DIFF
--- a/lib/travis/yaml/web/v1/decorators/config.rb
+++ b/lib/travis/yaml/web/v1/decorators/config.rb
@@ -3,6 +3,8 @@ require 'travis/yaml'
 module Travis::Yaml::Web::V1
   module Decorators
     class Config
+      LEVELS = %i(error warning info)
+
       def initialize(config)
         @config = config
       end
@@ -20,7 +22,7 @@ module Travis::Yaml::Web::V1
       private
 
       def messages
-        @config.msgs.map do |level, key, code, args|
+        sort(@config.msgs).map do |level, key, code, args|
           {
             'level'.freeze => level,
             'key'.freeze => key,
@@ -31,7 +33,11 @@ module Travis::Yaml::Web::V1
       end
 
       def full_messages
-        @config.msgs.map { |m| Travis::Yaml.msg(m) }
+        sort(@config.msgs).map { |m| Travis::Yaml.msg(m) }
+      end
+
+      def sort(msgs)
+        msgs.sort_by { |msg| LEVELS.index(msg.first) }
       end
     end
   end

--- a/spec/travis/yaml/web/v1_spec.rb
+++ b/spec/travis/yaml/web/v1_spec.rb
@@ -61,6 +61,14 @@ describe Travis::Yaml::Web::V1 do
       ]
     end
 
+    it 'sorts messages by severity' do
+      post '/parse', "rvm: 2.3\nbutt: true", {}
+      expect(response['messages'].map { |m| m['level'] }).to eq [
+        'error',
+        'info'
+      ]
+    end
+
     it 'returns full messages' do
       post '/parse', 'rvm: 2.3', {}
       expect(response['full_messages']).to eq [


### PR DESCRIPTION
This bumps `error` messages to the top, then `warning`, and lastly `info`.

https://github.com/travis-pro/team-teal/issues/2175