### PR TITLE
Disable patching of stdlib ::YAML, use LessYAML directly.

### DIFF
--- a/bin/bench
+++ b/bin/bench
@@ -10,7 +10,7 @@ require 'validate/local'
 require 'validate/record/message'
 
 configs = Record::Request.find([584594, 657002]).pluck(:config)
-configs = configs.map { |config| YAML.load(config) }
+configs = configs.map { |config| LessYAML.load(config) }
 ActiveRecord::Base.clear_active_connections!
 
 Travis::Yaml.expanded

--- a/lib/travis/yaml.rb
+++ b/lib/travis/yaml.rb
@@ -56,7 +56,7 @@ module Travis
       include Helper::Deyaml
 
       def load(yaml, opts = {})
-        hash = YAML.load(yaml.strip, raise_on_unknown_tag: true) || {}
+        hash = LessYAML.load(yaml.strip, raise_on_unknown_tag: true) || {}
         apply(hash, opts)
       end
 

--- a/lib/travis/yaml/support/less_yaml.rb
+++ b/lib/travis/yaml/support/less_yaml.rb
@@ -1,7 +1,7 @@
 $: << File.expand_path('../../../../../vendor/less_yaml/lib', __FILE__)
 
 require 'psych'
-require 'less_yaml'
+require 'less_yaml/load'
 
 module LessYAML
   OPTIONS[:default_mode] = :safe

--- a/lib/validate/config.rb
+++ b/lib/validate/config.rb
@@ -45,7 +45,7 @@ class Config
           return
         end
 
-        config = YAML.load(config)
+        config = LessYAML.load(config)
 
         if config.nil? || config.empty?
           result << [:warn, :config, :empty_config]

--- a/lib/validate/inspect.rb
+++ b/lib/validate/inspect.rb
@@ -9,7 +9,7 @@ class Inspect < Struct.new(:opts)
       result, record, msg = *msg
       puts format(result, record.request_id, msg)
       puts
-      config = YAML.load(Record::Request.find(record.request_id).config)
+      config = LessYAML.load(Record::Request.find(record.request_id).config)
       part = only(config, record.key.split('.').first)
       puts part.empty? ? config : part
     end

--- a/spec/docs_spec.rb
+++ b/spec/docs_spec.rb
@@ -15,7 +15,7 @@ LANG = {
 }
 
 def load_config(path)
-  YAML.load(File.read(path))
+  LessYAML.load(File.read(path))
 end
 
 def detect_lang(config)

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -4,7 +4,7 @@ require 'timeout'
 ENV['REQUESTS'] ||= 'true' if $*.join.include?(File.basename(__FILE__))
 
 def load_config(path)
-  YAML.load(File.read(path))
+  LessYAML.load(File.read(path))
 end
 
 describe Travis::Yaml do


### PR DESCRIPTION
I don't know if you guys rely on this monkey patch for other things internally, but currently many apps/libs depend on the behaviour of the standard ::YAML. Also see https://github.com/dtao/safe_yaml/issues/47.

An example:
```ruby
#!/usr/bin/env ruby
require 'date'
require 'yaml'
# uncomment the below and break things
# require 'travis/yaml'

puts YAML.load(':mykey: myvalue')[:mykey]
```