### PR TITLE
fix: "TypeError: no implicit conversion of nil into String" on GET /

### DIFF
--- a/lib/travis/yaml/web.rb
+++ b/lib/travis/yaml/web.rb
@@ -7,7 +7,9 @@ module Travis
 
       def call(env)
         req = Rack::Request.new(env)
-        prefix = ?/ + req.path_info.split(?/)[1]
+        path_info = req.path_info.split(?/)[1]
+        path_info = "" if !path_info
+        prefix = ?/ + path_info
         versions.each do |p, app|
           if p == prefix
             req.path_info = req.path_info[p.size..-1]


### PR DESCRIPTION
A call on `http://localhost:5000` returns  a HTTP 500 error instead of a 404 with the following stack trace:
```
08:49:35 web.1  | 2018-07-11 08:49:35 +0000: Rack app error handling request { GET / }
08:49:35 web.1  | #<TypeError: no implicit conversion of nil into String>
08:49:35 web.1  | /data/travis-yml/lib/travis/yaml/web.rb:10:in `+'
08:49:35 web.1  | /data/travis-yml/lib/travis/yaml/web.rb:10:in `call'
08:49:35 web.1  | /data/travis-yml/lib/travis/yaml/web/basic_auth.rb:11:in `call'
08:49:35 web.1  | /usr/local/bundle/gems/puma-3.11.2/lib/puma/configuration.rb:225:in `call'
08:49:35 web.1  | /usr/local/bundle/gems/puma-3.11.2/lib/puma/server.rb:624:in `handle_request'
08:49:35 web.1  | /usr/local/bundle/gems/puma-3.11.2/lib/puma/server.rb:438:in `process_client'
08:49:35 web.1  | /usr/local/bundle/gems/puma-3.11.2/lib/puma/server.rb:302:in `block in run'
08:49:35 web.1  | /usr/local/bundle/gems/puma-3.11.2/lib/puma/thread_pool.rb:120:in `block in spawn_thread'
`````

the fix is probably not idiomatic ruby, but it solves the problem

Regards