### PR TITLE
Standarize on jobs, make matrix the alias

### DIFF
--- a/lib/travis/yml.rb
+++ b/lib/travis/yml.rb
@@ -42,7 +42,7 @@ module Travis
     MSGS = {
       alias_key:         'the key %{alias} is an alias for %{key}, using %{key}',
       alias_value:       'the value %{alias} is an alias for %{value}, using %{value}',
-      overwrite:         'using both %{key} and %{other}. %{key} overwrites %{other}',
+      overwrite:         'both %{key} and %{other} given. %{key} overwrites %{other}',
       default:           'missing %{key}, using the default %<default>p',
       deprecated:        'deprecated: %{info}',
       deprecated_key:    'deprecated key: %<key>p (%{info})',

--- a/lib/travis/yml/matrix.rb
+++ b/lib/travis/yml/matrix.rb
@@ -106,7 +106,7 @@ module Travis
 
         def values
           values = config.select { |key, value| keys.include?(key) && ![[], nil].include?(value) }
-          values = values.map { |key, value| key == :env && value.is_a?(Hash) && value.key?(:matrix) ? value[:matrix] : value }
+          values = values.map { |key, value| key == :env && value.is_a?(Hash) && value.key?(:jobs) ? value[:jobs] : value }
           values = values.map { |value| wrap(value) }
           values
         end

--- a/lib/travis/yml/matrix.rb
+++ b/lib/travis/yml/matrix.rb
@@ -87,13 +87,13 @@ module Travis
         end
 
         def included
-          return [] unless config[:matrix]
-          [config[:matrix][:include] || []].flatten
+          return [] unless config[:jobs]
+          [config[:jobs][:include] || []].flatten
         end
 
         def excluded
-          return [] unless config[:matrix]
-          [config[:matrix][:exclude] || []].flatten
+          return [] unless config[:jobs]
+          [config[:jobs][:exclude] || []].flatten
         end
 
         def excluded?(row)
@@ -106,13 +106,13 @@ module Travis
 
         def values
           values = config.select { |key, value| keys.include?(key) && ![[], nil].include?(value) }
-          values = values.map { |key, value| key == :env && value.is_a?(Hash) ? value[:matrix] : value }
+          values = values.map { |key, value| key == :env && value.is_a?(Hash) && value.key?(:matrix) ? value[:matrix] : value }
           values = values.map { |value| wrap(value) }
           values
         end
 
         def shared
-          @shared ||= config.reject { |key, value| key == :matrix || keys.include?(key) || [[], nil].include?(value) }
+          @shared ||= config.reject { |key, value| key == :jobs || keys.include?(key) || [[], nil].include?(value) }
         end
 
         def cleaned(rows)
@@ -133,7 +133,7 @@ module Travis
         end
 
         def expand_keys
-          Yml.expand_keys - [:matrix] + [:env] # TODO
+          Yml.expand_keys - [:jobs] + [:env] # TODO
         end
 
         def wrap(obj)

--- a/lib/travis/yml/schema/def/env.rb
+++ b/lib/travis/yml/schema/def/env.rb
@@ -15,10 +15,9 @@ module Travis
               The key `env` defines env vars that will be defined in the build
               environment.
 
-              Env vars can be specified as global or matrix vars. Global vars
-              will be defined on every job in the build's job matrix. Matrix
-              vars will expand the matrix, i.e. create one additional job per
-              entry.
+              Env vars can be specified as global or job vars. Global vars will
+              be defined on every job in the build's job matrix. Job vars will
+              expand the build matrix, i.e. create one additional job per entry.
 
               Env vars can be given either as strings or maps. If given as a
               string they can contain multiple key/value pairs.
@@ -30,10 +29,10 @@ module Travis
             type Class.new(Type::Map) {
               def define
                 normal
-                prefix :matrix
+                prefix :jobs
 
                 map :global, to: :env_vars, summary: 'Global environment variables to be defined on all jobs'
-                matrix :matrix, to: :env_vars, summary: 'Environment variables that expand the build matrix (creating one job per entry)'
+                matrix :jobs, to: :env_vars, alias: :matrix, summary: 'Environment variables that expand the build matrix (creating one job per entry)'
               end
             }
 
@@ -71,7 +70,7 @@ module Travis
               def define
                 example FOO: 'foo'
                 normal
-                map :'^(?!global|matrix)', to: :any, type: [:str, :num, :bool, :secure]
+                map :'^(?!global|jobs|matrix)', to: :any, type: [:str, :num, :bool, :secure]
                 strict false
               end
             }

--- a/lib/travis/yml/schema/def/jobs.rb
+++ b/lib/travis/yml/schema/def/jobs.rb
@@ -5,39 +5,42 @@ module Travis
   module Yml
     module Schema
       module Def
-        class Matrix < Type::Map
-          register :matrix
+        class Jobs < Type::Map
+          register :jobs
 
           def define
+            title 'Job Matrix'
             summary 'Build matrix definitions'
             see 'Build Matrix': 'https://docs.travis-ci.com/user/build-matrix/'
 
             normal
-            aliases :jobs
+            aliases :matrix
             prefix :include
 
-            map :include,        to: :matrix_entries, summary: 'Jobs to include to the build matrix'
-            map :exclude,        to: :matrix_entries, summary: 'Attributes of jobs to exclude from the build matrix'
-            map :allow_failures, to: :matrix_entries, alias: :allowed_failures, summary: 'Attributes of jobs that are allowed to fail'
+            map :include,        to: :jobs_entries, summary: 'Jobs to include to the build matrix'
+            map :exclude,        to: :jobs_entries, summary: 'Attributes of jobs to exclude from the build matrix'
+            map :allow_failures, to: :jobs_entries, alias: :allowed_failures, summary: 'Attributes of jobs that are allowed to fail'
             map :fast_finish,    to: :bool, alias: :fast_failure, summary: 'Allow the build to fail fast'
 
             export
           end
         end
 
-        class MatrixEntries < Type::Seq
-          register :matrix_entries
+        class JobsEntries < Type::Seq
+          register :jobs_entries
 
           def define
-            type :matrix_entry
+            title 'Job Matrix Entries'
+            type :jobs_entry
             export
           end
         end
 
-        class Entry < Type::Map
-          register :matrix_entry
+        class JobsEntry < Type::Map
+          register :jobs_entry
 
           def define
+            title 'Job Matrix Entry'
             strict false
             aliases :jobs
 

--- a/lib/travis/yml/schema/def/root.rb
+++ b/lib/travis/yml/schema/def/root.rb
@@ -6,8 +6,8 @@ require 'travis/yml/schema/def/dist'
 require 'travis/yml/schema/def/env'
 require 'travis/yml/schema/def/imports'
 require 'travis/yml/schema/def/job'
+require 'travis/yml/schema/def/jobs'
 require 'travis/yml/schema/def/language'
-require 'travis/yml/schema/def/matrix'
 require 'travis/yml/schema/def/notification'
 require 'travis/yml/schema/def/os'
 require 'travis/yml/schema/def/stack'
@@ -42,7 +42,7 @@ module Travis
             map    :env
             matrix :compiler,       to: :compilers
             map    :stages
-            map    :matrix,         alias: :jobs
+            map    :jobs,           alias: :matrix
             map    :notifications
 
             map    :version

--- a/schema.json
+++ b/schema.json
@@ -524,7 +524,7 @@
       "env": {
         "$id": "env",
         "title": "Env",
-        "description": "The key `env` defines env vars that will be defined in the build\nenvironment.\n\nEnv vars can be specified as global or matrix vars. Global vars\nwill be defined on every job in the build's job matrix. Matrix\nvars will expand the matrix, i.e. create one additional job per\nentry.\n\nEnv vars can be given either as strings or maps. If given as a\nstring they can contain multiple key/value pairs.",
+        "description": "The key `env` defines env vars that will be defined in the build\nenvironment.\n\nEnv vars can be specified as global or job vars. Global vars will\nbe defined on every job in the build's job matrix. Job vars will\nexpand the build matrix, i.e. create one additional job per entry.\n\nEnv vars can be given either as strings or maps. If given as a\nstring they can contain multiple key/value pairs.",
         "anyOf": [
           {
             "type": "object",
@@ -533,8 +533,11 @@
                 "$ref": "#/definitions/type/env_vars",
                 "summary": "Global environment variables to be defined on all jobs"
               },
-              "matrix": {
+              "jobs": {
                 "$ref": "#/definitions/type/env_vars",
+                "aliases": [
+                  "matrix"
+                ],
                 "summary": "Environment variables that expand the build matrix (creating one job per entry)",
                 "flags": [
                   "expand"
@@ -544,7 +547,7 @@
             "additionalProperties": false,
             "normal": true,
             "prefix": {
-              "key": "matrix"
+              "key": "jobs"
             }
           },
           {
@@ -564,7 +567,7 @@
           {
             "type": "object",
             "patternProperties": {
-              "^(?!global|matrix)": {
+              "^(?!global|jobs|matrix)": {
                 "anyOf": [
                   {
                     "type": "string"
@@ -9532,8 +9535,8 @@
     "haxe",
     "hhvm",
     "jdk",
+    "jobs",
     "julia",
-    "matrix",
     "mono",
     "nix",
     "node_js",

--- a/schema.json
+++ b/schema.json
@@ -46,10 +46,10 @@
         "stages": {
           "$ref": "#/definitions/type/stages"
         },
-        "matrix": {
-          "$ref": "#/definitions/type/matrix",
+        "jobs": {
+          "$ref": "#/definitions/type/jobs",
           "aliases": [
-            "jobs"
+            "matrix"
           ]
         },
         "notifications": {
@@ -866,6 +866,132 @@
           }
         }
       },
+      "jobs": {
+        "$id": "jobs",
+        "title": "Job Matrix",
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "include": {
+                "$ref": "#/definitions/type/jobs_entries",
+                "summary": "Jobs to include to the build matrix"
+              },
+              "exclude": {
+                "$ref": "#/definitions/type/jobs_entries",
+                "summary": "Attributes of jobs to exclude from the build matrix"
+              },
+              "allow_failures": {
+                "$ref": "#/definitions/type/jobs_entries",
+                "aliases": [
+                  "allowed_failures"
+                ],
+                "summary": "Attributes of jobs that are allowed to fail"
+              },
+              "fast_finish": {
+                "type": "boolean",
+                "aliases": [
+                  "fast_failure"
+                ],
+                "summary": "Allow the build to fail fast"
+              }
+            },
+            "additionalProperties": false,
+            "see": {
+              "Build Matrix": "https://docs.travis-ci.com/user/build-matrix/"
+            },
+            "normal": true,
+            "aliases": [
+              "matrix"
+            ],
+            "prefix": {
+              "key": "include"
+            }
+          },
+          {
+            "$ref": "#/definitions/type/jobs_entries"
+          }
+        ],
+        "summary": "Build matrix definitions",
+        "see": {
+          "Build Matrix": "https://docs.travis-ci.com/user/build-matrix/"
+        },
+        "normal": true
+      },
+      "jobs_entries": {
+        "$id": "jobs_entries",
+        "title": "Job Matrix Entries",
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/type/jobs_entry"
+            },
+            "normal": true
+          },
+          {
+            "$ref": "#/definitions/type/jobs_entry"
+          }
+        ]
+      },
+      "jobs_entry": {
+        "$id": "jobs_entry",
+        "title": "Job Matrix Entry",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "language": {
+                "$ref": "#/definitions/type/language"
+              },
+              "os": {
+                "$ref": "#/definitions/type/os"
+              },
+              "dist": {
+                "$ref": "#/definitions/type/dist"
+              },
+              "arch": {
+                "$ref": "#/definitions/type/arch"
+              },
+              "sudo": {
+                "$ref": "#/definitions/type/sudo"
+              },
+              "env": {
+                "$ref": "#/definitions/type/env_vars"
+              },
+              "compiler": {
+                "type": "string",
+                "example": "gcc",
+                "only": {
+                  "language": [
+                    "c",
+                    "cpp"
+                  ]
+                }
+              },
+              "name": {
+                "type": "string",
+                "flags": [
+                  "unique"
+                ]
+              },
+              "stage": {
+                "type": "string"
+              }
+            },
+            "title": "Job Matrix Entry",
+            "aliases": [
+              "jobs"
+            ]
+          },
+          {
+            "$ref": "#/definitions/type/support"
+          },
+          {
+            "$ref": "#/definitions/type/job"
+          }
+        ]
+      },
       "language": {
         "$id": "language",
         "title": "Language",
@@ -1148,131 +1274,6 @@
           }
         ],
         "normal": true
-      },
-      "matrix": {
-        "$id": "matrix",
-        "title": "Matrix",
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "include": {
-                "$ref": "#/definitions/type/matrix_entries",
-                "summary": "Jobs to include to the build matrix"
-              },
-              "exclude": {
-                "$ref": "#/definitions/type/matrix_entries",
-                "summary": "Attributes of jobs to exclude from the build matrix"
-              },
-              "allow_failures": {
-                "$ref": "#/definitions/type/matrix_entries",
-                "aliases": [
-                  "allowed_failures"
-                ],
-                "summary": "Attributes of jobs that are allowed to fail"
-              },
-              "fast_finish": {
-                "type": "boolean",
-                "aliases": [
-                  "fast_failure"
-                ],
-                "summary": "Allow the build to fail fast"
-              }
-            },
-            "additionalProperties": false,
-            "see": {
-              "Build Matrix": "https://docs.travis-ci.com/user/build-matrix/"
-            },
-            "normal": true,
-            "aliases": [
-              "jobs"
-            ],
-            "prefix": {
-              "key": "include"
-            }
-          },
-          {
-            "$ref": "#/definitions/type/matrix_entries"
-          }
-        ],
-        "summary": "Build matrix definitions",
-        "see": {
-          "Build Matrix": "https://docs.travis-ci.com/user/build-matrix/"
-        },
-        "normal": true
-      },
-      "matrix_entries": {
-        "$id": "matrix_entries",
-        "title": "Matrix Entries",
-        "anyOf": [
-          {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/type/matrix_entry"
-            },
-            "normal": true
-          },
-          {
-            "$ref": "#/definitions/type/matrix_entry"
-          }
-        ]
-      },
-      "matrix_entry": {
-        "$id": "matrix_entry",
-        "title": "Matrix Entry",
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "language": {
-                "$ref": "#/definitions/type/language"
-              },
-              "os": {
-                "$ref": "#/definitions/type/os"
-              },
-              "dist": {
-                "$ref": "#/definitions/type/dist"
-              },
-              "arch": {
-                "$ref": "#/definitions/type/arch"
-              },
-              "sudo": {
-                "$ref": "#/definitions/type/sudo"
-              },
-              "env": {
-                "$ref": "#/definitions/type/env_vars"
-              },
-              "compiler": {
-                "type": "string",
-                "example": "gcc",
-                "only": {
-                  "language": [
-                    "c",
-                    "cpp"
-                  ]
-                }
-              },
-              "name": {
-                "type": "string",
-                "flags": [
-                  "unique"
-                ]
-              },
-              "stage": {
-                "type": "string"
-              }
-            },
-            "aliases": [
-              "jobs"
-            ]
-          },
-          {
-            "$ref": "#/definitions/type/support"
-          },
-          {
-            "$ref": "#/definitions/type/job"
-          }
-        ]
       },
       "notifications": {
         "$id": "notifications",

--- a/spec/integrate/configs_spec.rb
+++ b/spec/integrate/configs_spec.rb
@@ -457,7 +457,7 @@ describe Travis::Yml, configs: true do
     deploy.password
     deploy.script
     deploy.token
-    env.matrix.general
+    env.jobs.general
     language
     jobs.fast_finish
     jobs.allow_failures.rvm
@@ -501,8 +501,8 @@ describe Travis::Yml, configs: true do
       jobs.allow_failures
     ),
     seq: %i(
-      env.matrix.include
-      env.matrix.general
+      env.jobs.include
+      env.jobs.general
       jobs
       jobs.include.env.global
     ),
@@ -513,14 +513,14 @@ describe Travis::Yml, configs: true do
       deploy.env
       deploy.on.branch
       deploy.token
-      env.matrix
+      env.jobs
       jobs.include.cache.directories
       jobs.include.script
       jobs.include.after_script
       after_success
     ),
     secure: %i(
-      env.matrix.DJANGO_SECRET_KEY
+      env.jobs.DJANGO_SECRET_KEY
       env.global.github_token
     )
   }

--- a/spec/travis/yml/accept/addon/apt_spec.rb
+++ b/spec/travis/yml/accept/addon/apt_spec.rb
@@ -85,7 +85,7 @@ describe Travis::Yml, 'addon: apt' do
       it { should_not have_msg }
     end
 
-    describe 'given seq references including seq references on matrix.include.addons.apt.packages (yes, people do this)' do
+    describe 'given seq references including seq references on jobs.include.addons.apt.packages (yes, people do this)' do
       yaml %(
         one: &one
           - one
@@ -93,7 +93,7 @@ describe Travis::Yml, 'addon: apt' do
         two: &two
           - *one
 
-        matrix:
+        jobs:
           include:
           - addons:
               apt:
@@ -106,7 +106,7 @@ describe Travis::Yml, 'addon: apt' do
         should serialize_to(
           one: ['one'],
           two: [['one']],
-          matrix: {
+          jobs: {
             include: [
               addons: {
                 apt: {

--- a/spec/travis/yml/accept/conditions_spec.rb
+++ b/spec/travis/yml/accept/conditions_spec.rb
@@ -110,8 +110,8 @@ describe Travis::Yml, 'conditions' do
         jobs:
           - if: 'branch = master'
       )
-      it { should serialize_to matrix: { include: [if: 'branch = master'] } }
-      it { should have_msg [:info, :root, :alias_key, alias: 'jobs', key: 'matrix'] }
+      it { should serialize_to jobs: { include: [if: 'branch = master'] } }
+      it { should_not have_msg }
     end
   end
 end

--- a/spec/travis/yml/accept/env_spec.rb
+++ b/spec/travis/yml/accept/env_spec.rb
@@ -5,7 +5,7 @@ describe Travis::Yml, 'env' do
     yaml %(
       env: FOO=foo
     )
-    it { should serialize_to env: { matrix: [FOO: 'foo'] } }
+    it { should serialize_to env: { jobs: [FOO: 'foo'] } }
     it { should_not have_msg }
   end
 
@@ -13,7 +13,7 @@ describe Travis::Yml, 'env' do
     yaml %(
       env: FOO=
     )
-    it { should serialize_to env: { matrix: [FOO: ''] } }
+    it { should serialize_to env: { jobs: [FOO: ''] } }
     it { should_not have_msg }
   end
 
@@ -21,7 +21,7 @@ describe Travis::Yml, 'env' do
     yaml %(
       env: FOO=foo BAR=bar
     )
-    it { should serialize_to env: { matrix: [FOO: 'foo', BAR: 'bar'] } }
+    it { should serialize_to env: { jobs: [FOO: 'foo', BAR: 'bar'] } }
     it { should_not have_msg }
   end
 
@@ -31,7 +31,7 @@ describe Travis::Yml, 'env' do
         - FOO=foo BAR=bar
         - BAZ=baz
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] } }
     it { should_not have_msg }
   end
 
@@ -41,7 +41,7 @@ describe Travis::Yml, 'env' do
         FOO=foo
         BAR=bar
     )
-    it { should serialize_to env: { matrix: [FOO: 'foo', BAR: 'bar'] } }
+    it { should serialize_to env: { jobs: [FOO: 'foo', BAR: 'bar'] } }
     it { should_not have_msg }
   end
 
@@ -49,8 +49,8 @@ describe Travis::Yml, 'env' do
     yaml %(
       env: FOO="
     )
-    it { should serialize_to env: { matrix: [{}] } }
-    it { should have_msg [:error, :'env.matrix', :invalid_env_var, var: 'FOO="'] }
+    it { should serialize_to env: { jobs: [{}] } }
+    it { should have_msg [:error, :'env.jobs', :invalid_env_var, var: 'FOO="'] }
   end
 
   describe 'given a secure' do
@@ -58,7 +58,7 @@ describe Travis::Yml, 'env' do
       env:
         secure: secure
     )
-    it { should serialize_to env: { matrix: [secure: 'secure'] } }
+    it { should serialize_to env: { jobs: [secure: 'secure'] } }
     it { should_not have_msg }
   end
 
@@ -68,7 +68,7 @@ describe Travis::Yml, 'env' do
         - FOO=foo
         - BAR=bar
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
     it { should_not have_msg }
   end
 
@@ -77,7 +77,7 @@ describe Travis::Yml, 'env' do
       env:
         -
     )
-    it { should serialize_to env: { matrix: [{}] } }
+    it { should serialize_to env: { jobs: [{}] } }
     it { should_not have_msg }
   end
 
@@ -88,7 +88,7 @@ describe Travis::Yml, 'env' do
         - FOO=foo
         - BAR=bar BAZ=baz
     )
-    it { should serialize_to env: { matrix: [{}, { FOO: 'foo' }, { BAR: 'bar', BAZ: 'baz' }] } }
+    it { should serialize_to env: { jobs: [{}, { FOO: 'foo' }, { BAR: 'bar', BAZ: 'baz' }] } }
     it { should_not have_msg }
   end
 
@@ -99,7 +99,7 @@ describe Travis::Yml, 'env' do
         - FOO=foo
         - BAR=bar BAZ=baz
     )
-    it { should serialize_to env: { matrix: [{}, { FOO: 'foo' }, { BAR: 'bar', BAZ: 'baz' }] } }
+    it { should serialize_to env: { jobs: [{}, { FOO: 'foo' }, { BAR: 'bar', BAZ: 'baz' }] } }
     it { should_not have_msg }
   end
 
@@ -110,7 +110,7 @@ describe Travis::Yml, 'env' do
         BAR:
           secure: str
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo', BAR: { secure: 'str' } }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo', BAR: { secure: 'str' } }] } }
     it { should_not have_msg }
   end
 
@@ -119,7 +119,7 @@ describe Travis::Yml, 'env' do
       env:
         secure: secure
     )
-    it { should serialize_to env: { matrix: [{ secure: 'secure' }] } }
+    it { should serialize_to env: { jobs: [{ secure: 'secure' }] } }
     it { should_not have_msg }
   end
 
@@ -129,7 +129,7 @@ describe Travis::Yml, 'env' do
         secure: secure
         FOO: foo
     )
-    it { should serialize_to env: { matrix: [{ secure: 'secure', FOO: 'foo' }] } }
+    it { should serialize_to env: { jobs: [{ secure: 'secure', FOO: 'foo' }] } }
     it { should_not have_msg }
   end
 
@@ -139,7 +139,7 @@ describe Travis::Yml, 'env' do
         - secure: one
         - secure: two
     )
-    it { should serialize_to env: { matrix: [{ secure: 'one' }, { secure: 'two' }] } }
+    it { should serialize_to env: { jobs: [{ secure: 'one' }, { secure: 'two' }] } }
     it { should_not have_msg }
   end
 
@@ -149,7 +149,7 @@ describe Travis::Yml, 'env' do
         - FOO: foo
         - BAR: bar
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
     it { should_not have_msg }
   end
 
@@ -159,7 +159,7 @@ describe Travis::Yml, 'env' do
         - FOO: foo
         - BAR: bar
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
     it { should_not have_msg }
   end
 
@@ -168,20 +168,20 @@ describe Travis::Yml, 'env' do
       env:
         DEBUG: on
     )
-    it { should serialize_to env: { matrix: ['DEBUG=on'] } }
+    it { should serialize_to env: { jobs: ['DEBUG=on'] } }
     it { should_not have_msg }
   end
 
   describe 'given a map mixing known, unknown, and misplaced keys', v2: true, migrate: true do
-    let(:value) { { env: { FOO: 'foo', matrix: { BAR: 'bar' }, before_script: 'foo' } } }
-    # it { should serialize_to env: { matrix: [{ FOO: 'foo' }, { 'before_script=foo' }, { BAR: 'bar' }] } }
-    it { should have_msg [:warn, :env, :migrate_keys, keys: [:FOO, :before_script], to: 'matrix'] }
+    let(:value) { { env: { FOO: 'foo', jobs: { BAR: 'bar' }, before_script: 'foo' } } }
+    # it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { 'before_script=foo' }, { BAR: 'bar' }] } }
+    it { should have_msg [:warn, :env, :migrate_keys, keys: [:FOO, :before_script], to: 'jobs'] }
   end
 
   describe 'given a map mixing known and unknown keys holding arrays', v2: true, migrate: true do
-    let(:value) { { env: { general: [FOO: 'foo'], matrix: [BAR: 'bar'] } } }
-    it { should serialize_to env: { matrix: [BAR: 'bar', FOO: 'foo'] } }
-    it { should have_msg [:warn, :env, :migrate_keys, keys: [:general], to: 'matrix'] }
+    let(:value) { { env: { general: [FOO: 'foo'], jobs: [BAR: 'bar'] } } }
+    it { should serialize_to env: { jobs: [BAR: 'bar', FOO: 'foo'] } }
+    it { should have_msg [:warn, :env, :migrate_keys, keys: [:general], to: 'jobs'] }
   end
 
   describe 'given global' do
@@ -256,19 +256,52 @@ describe Travis::Yml, 'env' do
           global:
             secure: secure
       )
-      it { should serialize_to env: { matrix: [{ secure: 'secure' }], global: [{ secure: 'secure' }] } }
+      it { should serialize_to env: { jobs: [{ secure: 'secure' }], global: [{ secure: 'secure' }] } }
       it { should_not have_msg }
     end
   end
 
-  describe 'given matrix' do
+  describe 'given jobs' do
+    describe 'as a string' do
+      yaml %(
+        env:
+          jobs: FOO=foo
+      )
+      it { should serialize_to env: { jobs: [FOO: 'foo'] } }
+      it { should_not have_msg }
+    end
+
+    describe 'as a seq of strings' do
+      yaml %(
+        env:
+          jobs:
+            - FOO=foo
+            - BAR=bar
+      )
+      it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
+      it { should_not have_msg }
+    end
+
+    describe 'as a map' do
+      yaml %(
+        env:
+          jobs:
+            FOO: foo
+            BAR: bar
+      )
+      it { should serialize_to env: { jobs: [{ FOO: 'foo', BAR: 'bar' }] } }
+      it { should_not have_msg }
+    end
+  end
+
+  describe 'given matrix (alias)' do
     describe 'as a string' do
       yaml %(
         env:
           matrix: FOO=foo
       )
-      it { should serialize_to env: { matrix: [FOO: 'foo'] } }
-      it { should_not have_msg }
+      it { should serialize_to env: { jobs: [FOO: 'foo'] } }
+      it { should have_msg [:info, :env, :alias_key, alias: 'matrix', key: 'jobs' ] }
     end
 
     describe 'as a seq of strings' do
@@ -278,8 +311,8 @@ describe Travis::Yml, 'env' do
             - FOO=foo
             - BAR=bar
       )
-      it { should serialize_to env: { matrix: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
-      it { should_not have_msg }
+      it { should serialize_to env: { jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] } }
+      it { should have_msg [:info, :env, :alias_key, alias: 'matrix', key: 'jobs' ] }
     end
 
     describe 'as a map' do
@@ -289,8 +322,8 @@ describe Travis::Yml, 'env' do
             FOO: foo
             BAR: bar
       )
-      it { should serialize_to env: { matrix: [{ FOO: 'foo', BAR: 'bar' }] } }
-      it { should_not have_msg }
+      it { should serialize_to env: { jobs: [{ FOO: 'foo', BAR: 'bar' }] } }
+      it { should have_msg [:info, :env, :alias_key, alias: 'matrix', key: 'jobs' ] }
     end
   end
 
@@ -308,8 +341,8 @@ describe Travis::Yml, 'env' do
         one:
           two: str
     )
-    it { should serialize_to env: { matrix: [{ one: nil }] } }
-    it { should have_msg [:error, :'env.matrix.one', :invalid_type, expected: :str, actual: :map, value: { two: 'str' }] }
+    it { should serialize_to env: { jobs: [{ one: nil }] } }
+    it { should have_msg [:error, :'env.jobs.one', :invalid_type, expected: :str, actual: :map, value: { two: 'str' }] }
   end
 
   describe 'given a seq of strings, with an empty cache' do # ??
@@ -317,7 +350,7 @@ describe Travis::Yml, 'env' do
       cache:
       env: FOO=foo
     )
-    it { should serialize_to env: { matrix: [FOO: 'foo'] } }
+    it { should serialize_to env: { jobs: [FOO: 'foo'] } }
   end
 
   describe 'vim' do
@@ -325,7 +358,7 @@ describe Travis::Yml, 'env' do
       env:
         - FOO=foo "BAR='bar'"
     )
-    it { should serialize_to env: { matrix: [{ FOO: 'foo', BAR: "'bar'" }] } }
+    it { should serialize_to env: { jobs: [{ FOO: 'foo', BAR: "'bar'" }] } }
   end
 
   describe 'does not underscore keys (env)' do
@@ -333,7 +366,7 @@ describe Travis::Yml, 'env' do
       env:
         - API=str
     )
-    it { should serialize_to env: { matrix: [{ API: 'str' }] } }
+    it { should serialize_to env: { jobs: [{ API: 'str' }] } }
   end
 
   describe 'misplaced key with secure' do
@@ -344,6 +377,6 @@ describe Travis::Yml, 'env' do
         BAR:
           secure: str
     )
-    it { should serialize_to env: { global: [FOO: 'str'], matrix: [BAR: { secure: 'str' }] } }
+    it { should serialize_to env: { global: [FOO: 'str'], jobs: [BAR: { secure: 'str' }] } }
   end
 end

--- a/spec/travis/yml/accept/jobs_spec.rb
+++ b/spec/travis/yml/accept/jobs_spec.rb
@@ -1,23 +1,23 @@
-describe Travis::Yml, 'matrix' do
+describe Travis::Yml, 'jobs' do
   subject { described_class.apply(parse(yaml), opts) }
 
   describe 'fast_finish' do
     describe 'given true' do
       yaml %(
-        matrix:
-          fast_finish: true
-      )
-      it { should serialize_to matrix: { fast_finish: true } }
-      it { should_not have_msg }
-    end
-
-    describe 'on alias jobs' do
-      yaml %(
         jobs:
           fast_finish: true
       )
-      it { should serialize_to matrix: { fast_finish: true } }
-      it { should have_msg [:info, :root, :alias_key, alias: 'jobs', key: 'matrix'] }
+      it { should serialize_to jobs: { fast_finish: true } }
+      it { should_not have_msg }
+    end
+
+    describe 'on alias matrix' do
+      yaml %(
+        matrix:
+          fast_finish: true
+      )
+      it { should serialize_to jobs: { fast_finish: true } }
+      it { should have_msg [:info, :root, :alias_key, alias: 'matrix', key: 'jobs'] }
     end
 
     describe 'overwrite, using both matrix and jobs (1)' do
@@ -27,9 +27,9 @@ describe Travis::Yml, 'matrix' do
         jobs:
           - script: one
       )
-      it { should serialize_to matrix: { include: [script: ['one']] } }
-      it { should have_msg [:info, :root, :alias_key, alias: 'jobs', key: 'matrix'] }
-      it { should have_msg [:error, :root, :overwrite, key: 'jobs', other: 'matrix'] }
+      it { should serialize_to jobs: { fast_finish: true } }
+      it { should have_msg [:info, :root, :alias_key, alias: 'matrix', key: 'jobs'] }
+      it { should have_msg [:error, :root, :overwrite, key: 'matrix', other: 'jobs'] }
     end
 
     describe 'overwrite, using both matrix and jobs (2)' do
@@ -39,65 +39,65 @@ describe Travis::Yml, 'matrix' do
         matrix:
           fast_finish: true
       )
-      it { should serialize_to matrix: { include: [script: ['one']] } }
-      it { should have_msg [:info, :root, :alias_key, alias: 'jobs', key: 'matrix'] }
-      it { should have_msg [:error, :root, :overwrite, key: 'jobs', other: 'matrix'] }
+      it { should serialize_to jobs: { fast_finish: true } }
+      it { should have_msg [:info, :root, :alias_key, alias: 'matrix', key: 'jobs'] }
+      it { should have_msg [:error, :root, :overwrite, key: 'matrix', other: 'jobs'] }
     end
 
     describe 'alias fast_failure' do
       yaml %(
-        matrix:
+        jobs:
           fast_failure: true
       )
-      it { should serialize_to matrix: { fast_finish: true } }
-      it { should have_msg [:info, :matrix, :alias_key, alias: 'fast_failure', key: 'fast_finish'] }
+      it { should serialize_to jobs: { fast_finish: true } }
+      it { should have_msg [:info, :jobs, :alias_key, alias: 'fast_failure', key: 'fast_finish'] }
     end
   end
 
   describe 'prefix include' do
     describe 'given a map (rvm)' do
       yaml %(
-        matrix:
+        jobs:
           rvm: 2.3
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3'] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3'] } }
       it { should_not have_msg }
     end
 
     describe 'given a map (script)' do
       yaml %(
-        matrix:
+        jobs:
           script: str
       )
-      it { should serialize_to matrix: { include: [script: ['str']] } }
+      it { should serialize_to jobs: { include: [script: ['str']] } }
       it { should_not have_msg }
     end
 
     describe 'given a map (stage)' do
       yaml %(
-        matrix:
+        jobs:
           stage: str
       )
-      it { should serialize_to matrix: { include: [stage: 'str'] } }
+      it { should serialize_to jobs: { include: [stage: 'str'] } }
       it { should_not have_msg }
     end
 
     describe 'given a seq of maps' do
       yaml %(
-        matrix:
+        jobs:
           - rvm: 2.3
           - rvm: 2.4
       )
-      it { should serialize_to matrix: { include: [{ rvm: '2.3' }, { rvm: '2.4' }] } }
+      it { should serialize_to jobs: { include: [{ rvm: '2.3' }, { rvm: '2.4' }] } }
       it { should_not have_msg }
     end
 
-    describe 'given a seq of strings (misplaced env.matrix)' do
+    describe 'given a seq of strings (misplaced env.jobs)' do
       yaml %(
-        matrix:
+        jobs:
           - FOO=foo
       )
-      it { should have_msg [:error, :matrix, :invalid_type, expected: :map, actual: :seq, value: ['FOO=foo']] }
+      it { should have_msg [:error, :jobs, :invalid_type, expected: :map, actual: :seq, value: ['FOO=foo']] }
     end
 
     describe 'given a misplaced key :allow_failures', v2: true, migrate: true do
@@ -105,7 +105,7 @@ describe Travis::Yml, 'matrix' do
         allow_failures:
           - rvm: 2.3
       )
-      it { should serialize_to matrix: { allow_failures: [rvm: '2.3'] } }
+      it { should serialize_to jobs: { allow_failures: [rvm: '2.3'] } }
       it { should_not have_msg }
     end
 
@@ -114,298 +114,298 @@ describe Travis::Yml, 'matrix' do
         allowed_failures:
           - rvm: 2.3
       )
-      it { should serialize_to matrix: { allow_failures: [rvm: '2.3'] } }
-      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'matrix', value: [rvm: '2.3']] }
+      it { should serialize_to jobs: { allow_failures: [rvm: '2.3'] } }
+      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'jobs', value: [rvm: '2.3']] }
     end
   end
 
   describe 'include' do
     describe 'given true', drop: true do
       yaml %(
-        matrix:
+        jobs:
           include: true
       )
       it { should serialize_to empty }
-      it { should have_msg [:error, :"matrix.include", :invalid_type, expected: :map, actual: :bool, value: true] }
+      it { should have_msg [:error, :"jobs.include", :invalid_type, expected: :map, actual: :bool, value: true] }
     end
 
     describe 'given a seq of maps' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - rvm: 2.3
               stage: str
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3', stage: 'str'] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3', stage: 'str'] } }
       it { should_not have_msg }
     end
 
     describe 'given a map' do
       yaml %(
-        matrix:
+        jobs:
           include:
             rvm: 2.3
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3'] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3'] } }
       it { should_not have_msg }
     end
 
     describe 'given a nested map with a broken env string (missing newline)', drop: true do
       yaml %(
-        matrix:
+        jobs:
           include:
             mono:
               4.0.5env: EDITOR=nvim
       )
       it { should serialize_to empty }
-      it { should have_msg [:error, :'matrix.include.mono', :invalid_type, expected: :str, actual: :map, value: { :'4.0.5env' => 'EDITOR=nvim' }] }
+      it { should have_msg [:error, :'jobs.include.mono', :invalid_type, expected: :str, actual: :map, value: { :'4.0.5env' => 'EDITOR=nvim' }] }
     end
 
     describe 'given a seq of maps (with env given as a map)' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - rvm: 2.3
               env:
                 FOO: foo
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3', env: [FOO: 'foo']] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3', env: [FOO: 'foo']] } }
       it { should_not have_msg }
     end
 
     describe 'given a seq of maps (with rvm given as a string)' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - rvm: 2.3
               env: FOO=foo
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3', env: [FOO: 'foo']] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3', env: [FOO: 'foo']] } }
       it { should_not have_msg }
     end
 
     describe 'given a seq of maps (with env given as a seq of strings)' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - rvm: 2.3
               env:
               - FOO=foo
               - BAR=bar
       )
-      it { should serialize_to matrix: { include: [rvm: '2.3', env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
+      it { should serialize_to jobs: { include: [rvm: '2.3', env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
     end
 
     describe 'given env.global with a seq of maps', drop: true do
       yaml %(
-        matrix:
+        jobs:
           include:
             - env:
                 global:
                   - FOO: true
       )
-      it { should serialize_to matrix: { include: [env: [global: nil]] } }
-      it { should have_msg [:error, :'matrix.include.env.global', :invalid_type, expected: :str, actual: :seq, value: [FOO: true]] }
+      it { should serialize_to jobs: { include: [env: [global: nil]] } }
+      it { should have_msg [:error, :'jobs.include.env.global', :invalid_type, expected: :str, actual: :seq, value: [FOO: true]] }
     end
 
     describe 'given language (str)' do
       yaml %(
-        matrix:
+        jobs:
           include:
             language: ruby
       )
-      it { should serialize_to matrix: { include: [language: 'ruby'] } }
+      it { should serialize_to jobs: { include: [language: 'ruby'] } }
       it { should_not have_msg }
     end
 
     describe 'given language (seq)' do
       yaml %(
-        matrix:
+        jobs:
           include:
             language:
             - ruby
       )
-      it { should serialize_to matrix: { include: [language: 'ruby'] } }
-      it { should have_msg [:warn, :'matrix.include.language', :unexpected_seq, value: 'ruby'] }
+      it { should serialize_to jobs: { include: [language: 'ruby'] } }
+      it { should have_msg [:warn, :'jobs.include.language', :unexpected_seq, value: 'ruby'] }
     end
 
     describe 'given language with a typo' do
       yaml %(
-        matrix:
+        jobs:
           include:
             language: ruby`
       )
-      it { should serialize_to matrix: { include: [language: 'ruby'] } }
-      it { should have_msg [:warn, :'matrix.include.language', :find_value, original: 'ruby`', value: 'ruby'] }
+      it { should serialize_to jobs: { include: [language: 'ruby'] } }
+      it { should have_msg [:warn, :'jobs.include.language', :find_value, original: 'ruby`', value: 'ruby'] }
     end
 
     describe 'given jdk (str)' do
       yaml %(
-        matrix:
+        jobs:
           include:
           - language: ruby
             jdk: str
       )
-      it { should serialize_to matrix: { include: [language: 'ruby', jdk: 'str'] } }
+      it { should serialize_to jobs: { include: [language: 'ruby', jdk: 'str'] } }
       it { should_not have_msg }
     end
 
     describe 'given jdk (seq)' do
       yaml %(
-        matrix:
+        jobs:
           include:
           - language: ruby
             jdk:
             - str
       )
-      it { should serialize_to matrix: { include: [language: 'ruby', jdk: 'str'] } }
-      it { should have_msg [:warn, :'matrix.include.jdk', :unexpected_seq, value: 'str'] }
+      it { should serialize_to jobs: { include: [language: 'ruby', jdk: 'str'] } }
+      it { should have_msg [:warn, :'jobs.include.jdk', :unexpected_seq, value: 'str'] }
     end
 
     describe 'given compiler (str)' do
       yaml %(
-        matrix:
+        jobs:
           include:
           - language: cpp
             compiler: str
       )
-      it { should serialize_to matrix: { include: [language: 'cpp', compiler: 'str'] } }
+      it { should serialize_to jobs: { include: [language: 'cpp', compiler: 'str'] } }
       it { should_not have_msg }
     end
 
     describe 'given compiler (seq)' do
       yaml %(
-        matrix:
+        jobs:
           include:
           - language: cpp
             compiler:
             - str
       )
-      it { should serialize_to matrix: { include: [language: 'cpp', compiler: 'str'] } }
-      it { should have_msg [:warn, :'matrix.include.compiler', :unexpected_seq, value: 'str'] }
+      it { should serialize_to jobs: { include: [language: 'cpp', compiler: 'str'] } }
+      it { should have_msg [:warn, :'jobs.include.compiler', :unexpected_seq, value: 'str'] }
     end
 
     describe 'given licenses' do
       yaml %(
-        matrix:
+        jobs:
           include:
           - language: android
             android:
               licenses:
                 - str
       )
-      it { should serialize_to matrix: { include: [language: 'android', android: { licenses: ['str'] }] } }
+      it { should serialize_to jobs: { include: [language: 'android', android: { licenses: ['str'] }] } }
       it { should_not have_msg }
     end
 
     describe 'unknown value, with an unsupported key' do
       yaml %(
-        matrix:
+        jobs:
           include:
             language: node_js - 9
             compiler: gcc
       )
-      it { should serialize_to matrix: { include: [language: 'node_js', compiler: 'gcc'] } }
-      it { should have_msg [:warn, :'matrix.include.language', :clean_value, original: 'node_js - 9', value: 'node_js'] }
-      it { should have_msg [:warn, :'matrix.include.compiler', :unsupported, on_key: 'language', on_value: 'node_js', key: 'compiler', value: 'gcc'] }
+      it { should serialize_to jobs: { include: [language: 'node_js', compiler: 'gcc'] } }
+      it { should have_msg [:warn, :'jobs.include.language', :clean_value, original: 'node_js - 9', value: 'node_js'] }
+      it { should have_msg [:warn, :'jobs.include.compiler', :unsupported, on_key: 'language', on_value: 'node_js', key: 'compiler', value: 'gcc'] }
     end
 
     describe 'given a name' do
       yaml %(
-        matrix:
+        jobs:
           include:
             name: name
       )
-      it { should serialize_to matrix: { include: [name: 'name'] } }
+      it { should serialize_to jobs: { include: [name: 'name'] } }
       it { should_not have_msg }
     end
 
     describe 'given duplicate names' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - name: name
             - name: name
       )
-      it { should serialize_to matrix: { include: [{ name: 'name' }, { name: 'name' }] } }
-      it { should have_msg [:info, :'matrix.include', :duplicate, values: 'name: name'] }
+      it { should serialize_to jobs: { include: [{ name: 'name' }, { name: 'name' }] } }
+      it { should have_msg [:info, :'jobs.include', :duplicate, values: 'name: name'] }
     end
 
     describe 'given addons' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - addons:
                 apt: package
       )
-      it { should serialize_to matrix: { include: [addons: { apt: { packages: ['package'] } }] } }
+      it { should serialize_to jobs: { include: [addons: { apt: { packages: ['package'] } }] } }
       it { should_not have_msg }
     end
 
     describe 'given branches' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - branches:
                 only: master
       )
-      it { should serialize_to matrix: { include: [branches: { only: ['master'] }] } }
+      it { should serialize_to jobs: { include: [branches: { only: ['master'] }] } }
       it { should_not have_msg }
     end
 
     describe 'given a condition' do
       describe 'valid' do
         yaml %(
-          matrix:
+          jobs:
             include:
               - if: 'branch = master'
         )
-        it { should serialize_to matrix: { include: [if: 'branch = master'] } }
+        it { should serialize_to jobs: { include: [if: 'branch = master'] } }
         it { should_not have_msg }
       end
 
       describe 'invalid' do
         yaml %(
-          matrix:
+          jobs:
             include:
               if: '= foo'
         )
         it { should serialize_to empty }
-        it { should have_msg [:error, :'matrix.include.if', :invalid_condition, condition: '= foo'] }
+        it { should have_msg [:error, :'jobs.include.if', :invalid_condition, condition: '= foo'] }
       end
     end
 
     describe 'given a misplaced env' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - os: linux
           env:
             - FOO=str
       )
-      it { should serialize_to matrix: { include: [os: 'linux'], env: ['FOO=str'] } }
-      it { should have_msg [:warn, :matrix, :unknown_key, key: 'env', value: ['FOO=str']] }
+      it { should serialize_to jobs: { include: [os: 'linux'], env: ['FOO=str'] } }
+      it { should have_msg [:warn, :jobs, :unknown_key, key: 'env', value: ['FOO=str']] }
     end
 
     describe 'given a misplaced key' do
       yaml %(
-        matrix:
+        jobs:
           include:
             env:
               DEBUG: on
       )
-      it { should serialize_to matrix: { include: [env: [DEBUG: 'on']] } }
+      it { should serialize_to jobs: { include: [env: [DEBUG: 'on']] } }
       it { should_not have_msg }
     end
 
     describe 'given an unknown os' do
       yaml %(
-        matrix:
+        jobs:
           include:
             - os: unknown
       )
-      it { should serialize_to matrix: { include: [os: 'linux'] } }
-      it { should have_msg [:warn, :'matrix.include.os', :unknown_default, value: 'unknown', default: 'linux'] }
+      it { should serialize_to jobs: { include: [os: 'linux'] } }
+      it { should have_msg [:warn, :'jobs.include.os', :unknown_default, value: 'unknown', default: 'linux'] }
     end
   end
 
@@ -413,110 +413,110 @@ describe Travis::Yml, 'matrix' do
     describe key.to_s do
       describe 'given a map' do
         yaml %(
-          matrix:
+          jobs:
             #{key}:
               rvm: 2.3
         )
-        it { should serialize_to matrix: { key => [rvm: '2.3'] } }
+        it { should serialize_to jobs: { key => [rvm: '2.3'] } }
         it { should_not have_msg }
       end
 
       describe 'given a seq of maps' do
         yaml %(
-          matrix:
+          jobs:
             #{key}:
               - rvm: 2.3
         )
-        it { should serialize_to matrix: { key => [rvm: '2.3'] } }
+        it { should serialize_to jobs: { key => [rvm: '2.3'] } }
         it { should_not have_msg }
       end
 
       describe 'given true', drop: true do
         yaml %(
-          matrix:
+          jobs:
             #{key}: true
         )
         it { should serialize_to empty }
-        it { should have_msg [:error, :"matrix.#{key}", :invalid_type, expected: :map, actual: :bool, value: true] }
+        it { should have_msg [:error, :"jobs.#{key}", :invalid_type, expected: :map, actual: :bool, value: true] }
       end
 
       describe 'default language', defaults: true do
         yaml %(
-          matrix:
+          jobs:
             #{key}:
               rvm: 2.3
         )
-        it { should serialize_to language: 'ruby', os: ['linux'], matrix: { key => [rvm: '2.3'] } }
+        it { should serialize_to language: 'ruby', os: ['linux'], jobs: { key => [rvm: '2.3'] } }
       end
 
       describe 'given language' do
         yaml %(
-          matrix:
+          jobs:
             #{key}:
               language: ruby
         )
-        it { should serialize_to matrix: { key => [language: 'ruby'] } }
+        it { should serialize_to jobs: { key => [language: 'ruby'] } }
         it { should_not have_msg }
       end
 
       describe 'env' do
         describe 'given as string' do
           yaml %(
-            matrix:
+            jobs:
               #{key}:
                 env: 'FOO=foo BAR=bar'
           )
-          it { should serialize_to matrix: { key => [env: [{ FOO: 'foo', BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo', BAR: 'bar' }]] } }
           it { should_not have_msg }
         end
 
         describe 'given as a seq of strings' do
           yaml %(
-            matrix:
+            jobs:
               #{key}:
                 env:
                   - FOO=foo
                   - BAR=bar
           )
-          it { should serialize_to matrix: { key => [env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
           it { should_not have_msg }
         end
 
         describe 'given as a map' do
           yaml %(
-            matrix:
+            jobs:
               #{key}:
                 env:
                   FOO: foo
                   BAR: bar
           )
-          it { should serialize_to matrix: { key => [env: [{ FOO: 'foo', BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo', BAR: 'bar' }]] } }
           it { should_not have_msg }
         end
 
         describe 'given as a seq of maps' do
           yaml %(
-            matrix:
+            jobs:
               #{key}:
                 env:
                   - FOO: foo
                   - BAR: bar
           )
-          it { should serialize_to matrix: { key => [env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
           it { should_not have_msg }
         end
       end
 
       describe 'given licenses' do
         yaml %(
-          matrix:
+          jobs:
             #{key}:
             - language: android
               android:
                 licenses:
                   - str
         )
-        it { should serialize_to matrix: { key => [language: 'android', android: { licenses: ['str'] }] } }
+        it { should serialize_to jobs: { key => [language: 'android', android: { licenses: ['str'] }] } }
         it { should_not have_msg }
       end
 
@@ -524,37 +524,37 @@ describe Travis::Yml, 'matrix' do
         describe 'language given on root' do
           yaml %(
             language: ruby
-            matrix:
+            jobs:
               #{key}:
                 - rvm: 2.3
                   python: 3.5
           )
-          it { should serialize_to language: 'ruby', matrix: { key => [rvm: '2.3', python: '3.5'] } }
-          it { should have_msg [:warn, :"matrix.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
+          it { should serialize_to language: 'ruby', jobs: { key => [rvm: '2.3', python: '3.5'] } }
+          it { should have_msg [:warn, :"jobs.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
         end
 
-        describe "language given on matrix.#{key}" do
+        describe "language given on jobs.#{key}" do
           yaml %(
-            matrix:
+            jobs:
               #{key}:
                 - language: ruby
                   rvm: 2.3
                   python: 3.5
           )
-          it { should serialize_to matrix: { key => [language: 'ruby', rvm: '2.3', python: '3.5'] } }
-          it { should have_msg [:warn, :"matrix.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
+          it { should serialize_to jobs: { key => [language: 'ruby', rvm: '2.3', python: '3.5'] } }
+          it { should have_msg [:warn, :"jobs.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
         end
 
         describe 'in separate entries' do
           yaml %(
             language: ruby
-            matrix:
+            jobs:
               #{key}:
                 - rvm: 2.3
                 - python: 3.5
           )
-          it { should serialize_to language: 'ruby', matrix: { key => [{ rvm: '2.3' }, { python: '3.5' }] } }
-          it { should have_msg [:warn, :"matrix.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
+          it { should serialize_to language: 'ruby', jobs: { key => [{ rvm: '2.3' }, { python: '3.5' }] } }
+          it { should have_msg [:warn, :"jobs.#{key}.python", :unsupported, on_key: 'language', on_value: 'ruby', key: 'python', value: '3.5'] }
         end
       end
     end
@@ -563,29 +563,29 @@ describe Travis::Yml, 'matrix' do
   describe 'allow_failures' do
     describe "alias allowed_failures" do
       yaml %(
-        matrix:
+        jobs:
           allowed_failures:
             rvm: 2.3
       )
-      it { should serialize_to matrix: { allow_failures: [rvm: '2.3'] } }
-      it { should have_msg [:info, :matrix, :alias_key, alias: 'allowed_failures', key: 'allow_failures'] }
+      it { should serialize_to jobs: { allow_failures: [rvm: '2.3'] } }
+      it { should have_msg [:info, :jobs, :alias_key, alias: 'allowed_failures', key: 'allow_failures'] }
     end
 
     describe 'allow_failures given a seq of strings (common mistake)', drop: true do
       yaml %(
-        matrix:
+        jobs:
           allowed_failures:
             - 2.3
       )
       it { should serialize_to empty }
-      it { should have_msg [:error, :'matrix.allow_failures', :invalid_type, expected: :map, actual: :str, value: '2.3'] }
+      it { should have_msg [:error, :'jobs.allow_failures', :invalid_type, expected: :map, actual: :str, value: '2.3'] }
     end
 
     describe 'misplaced on root', v2: true, migrate: true do
       yaml %(
       )
-      it { should serialize_to matrix: { allow_failures: [rvm: '2.3'] } }
-      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'matrix', value: [rvm: '2.3']] }
+      it { should serialize_to jobs: { allow_failures: [rvm: '2.3'] } }
+      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'jobs', value: [rvm: '2.3']] }
     end
 
     describe 'alias allowed_failures, misplaced on root', v2: true, migrate: true do
@@ -593,27 +593,27 @@ describe Travis::Yml, 'matrix' do
         allowed_failures:
           rvm: 2.3
       )
-      it { should serialize_to matrix: { allow_failures: [rvm: '2.3'] } }
-      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'matrix', value: [rvm: '2.3']] }
+      it { should serialize_to jobs: { allow_failures: [rvm: '2.3'] } }
+      it { should have_msg [:warn, :root, :migrate, key: 'allow_failures', to: 'jobs', value: [rvm: '2.3']] }
     end
   end
 
   describe 'misplaced keys', v2: true, migrate: true do
     yaml %(
-      matrix:
+      jobs:
         include:
           - apt:
               packages: clang
           - apt:
     )
-    it { should serialize_to matrix: { include: [addons: { apt: { packages: ['clang'] } }] } }
-    it { should have_msg [:warn, :'matrix.include', :migrate, key: 'apt', to: 'addons', value: { packages: ['clang'] }] }
-    it { should have_msg [:warn, :'matrix.include', :migrate, key: 'apt', to: 'addons', value: nil] }
+    it { should serialize_to jobs: { include: [addons: { apt: { packages: ['clang'] } }] } }
+    it { should have_msg [:warn, :'jobs.include', :migrate, key: 'apt', to: 'addons', value: { packages: ['clang'] }] }
+    it { should have_msg [:warn, :'jobs.include', :migrate, key: 'apt', to: 'addons', value: nil] }
   end
 
   describe 'duplicate values' do
     yaml %(
-      matrix:
+      jobs:
         include:
           - if: type = cron
             node_js: 10.7

--- a/spec/travis/yml/accept/osx_image_spec.rb
+++ b/spec/travis/yml/accept/osx_image_spec.rb
@@ -50,6 +50,6 @@ describe Travis::Yml, 'osx_image' do
           - os: osx
             osx_image: xcode8.2
     )
-    it { should serialize_to matrix: { include: [os: 'osx', osx_image: ['xcode8.2']] } }
+    it { should serialize_to jobs: { include: [os: 'osx', osx_image: ['xcode8.2']] } }
   end
 end

--- a/spec/travis/yml/doc/accept/changes/type_spec.rb
+++ b/spec/travis/yml/doc/accept/changes/type_spec.rb
@@ -295,8 +295,8 @@ describe Travis::Yml::Doc::Change do
     end
   end
 
-  describe 'matrix.include' do
-    let(:schema) { Travis::Yml.expand['matrix'] }
+  describe 'jobs.include' do
+    let(:schema) { Travis::Yml.expand['jobs'] }
 
     describe 'a str' do
       let(:value) { { include: ['foo'] } }

--- a/spec/travis/yml/doc/accept/changes/type_spec.rb
+++ b/spec/travis/yml/doc/accept/changes/type_spec.rb
@@ -156,52 +156,52 @@ describe Travis::Yml::Doc::Change do
 
     describe 'a str' do
       let(:value) { 'foo' }
-      it { should serialize_to matrix: [foo: ''] }
+      it { should serialize_to jobs: [foo: ''] }
     end
 
     describe 'a seq of strs' do
       let(:value) { ['foo'] }
-      it { should serialize_to matrix: [foo: ''] }
+      it { should serialize_to jobs: [foo: ''] }
     end
 
     describe 'a var' do
       let(:value) { 'FOO=foo' }
-      it { should serialize_to matrix: [FOO: 'foo'] }
+      it { should serialize_to jobs: [FOO: 'foo'] }
     end
 
     describe 'an empty var' do
       let(:value) { 'FOO=' }
-      it { should serialize_to matrix: [FOO: ''] }
+      it { should serialize_to jobs: [FOO: ''] }
     end
 
     describe 'several vars' do
       let(:value) { 'FOO=foo BAR=bar' }
-      it { should serialize_to matrix: [{ FOO: 'foo', BAR: 'bar' }] }
+      it { should serialize_to jobs: [{ FOO: 'foo', BAR: 'bar' }] }
     end
 
     describe 'a seq of vars' do
       let(:value) { ['FOO=foo BAR=bar', 'BAZ=baz'] }
-      it { should serialize_to matrix: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] }
+      it { should serialize_to jobs: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] }
     end
 
     describe 'a secure' do
       let(:value) { { 'secure' => 'foo' } }
-      it { should serialize_to matrix: [secure: 'foo'] }
+      it { should serialize_to jobs: [secure: 'foo'] }
     end
 
     describe 'a seq of secures' do
       let(:value) { [secure: 'foo'] }
-      it { should serialize_to matrix: [secure: 'foo'] }
+      it { should serialize_to jobs: [secure: 'foo'] }
     end
 
     describe 'a map' do
       let(:value) { { 'FOO' => 'foo', 'BAR' => 'bar' } }
-      it { should serialize_to matrix: [{ FOO: 'foo', BAR: 'bar' }] }
+      it { should serialize_to jobs: [{ FOO: 'foo', BAR: 'bar' }] }
     end
 
     describe 'a seq of maps' do
       let(:value) { [{ 'FOO' => 'foo', 'BAR' => 'bar' }, { 'BAZ' => 'baz' }] }
-      it { should serialize_to matrix: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] }
+      it { should serialize_to jobs: [{ FOO: 'foo', BAR: 'bar' }, { BAZ: 'baz' }] }
     end
 
     describe 'a seq of mixed vars, maps, and secures' do
@@ -216,7 +216,7 @@ describe Travis::Yml::Doc::Change do
       end
 
       it do
-        should serialize_to matrix: [
+        should serialize_to jobs: [
           { FOO: 'foo', BAR: 'bar' },
           { BAZ: 'baz' },
           { BUZ: 'buz' },
@@ -227,47 +227,47 @@ describe Travis::Yml::Doc::Change do
     end
   end
 
-  describe 'env.matrix' do
+  describe 'env.jobs' do
     let(:schema) { Travis::Yml.expand['env'] }
 
     describe 'a str' do
-      let(:value) { { matrix: 'foo' } }
-      it { should serialize_to matrix: [foo: ''] }
+      let(:value) { { jobs: 'foo' } }
+      it { should serialize_to jobs: [foo: ''] }
     end
 
     describe 'a seq of strs' do
-      let(:value) { { matrix: ['foo'] } }
-      it { should serialize_to matrix: [foo: ''] }
+      let(:value) { { jobs: ['foo'] } }
+      it { should serialize_to jobs: [foo: ''] }
     end
 
     describe 'a var' do
-      let(:value) { { matrix: 'FOO=foo' } }
-      it { should serialize_to matrix: [FOO: 'foo'] }
+      let(:value) { { jobs: 'FOO=foo' } }
+      it { should serialize_to jobs: [FOO: 'foo'] }
     end
 
     describe 'a seq of vars' do
-      let(:value) { { matrix: ['FOO=foo', 'BAR=bar'] } }
-      it { should serialize_to matrix: [{ FOO: 'foo' }, { BAR: 'bar' }] }
+      let(:value) { { jobs: ['FOO=foo', 'BAR=bar'] } }
+      it { should serialize_to jobs: [{ FOO: 'foo' }, { BAR: 'bar' }] }
     end
 
     describe 'a secure' do
-      let(:value) { { matrix: { secure: 'foo' } } }
-      it { should serialize_to matrix: [secure: 'foo'] }
+      let(:value) { { jobs: { secure: 'foo' } } }
+      it { should serialize_to jobs: [secure: 'foo'] }
     end
 
     describe 'a seq of secures' do
-      let(:value) { { matrix: [secure: 'foo'] } }
-      it { should serialize_to matrix: [secure: 'foo'] }
+      let(:value) { { jobs: [secure: 'foo'] } }
+      it { should serialize_to jobs: [secure: 'foo'] }
     end
 
     describe 'a map' do
-      let(:value) { { matrix: { foo: 'foo' } } }
-      it { should serialize_to matrix: [foo: 'foo'] }
+      let(:value) { { jobs: { foo: 'foo' } } }
+      it { should serialize_to jobs: [foo: 'foo'] }
     end
 
     describe 'a seq of maps' do
-      let(:value) { { matrix: [foo: 'foo'] } }
-      it { should serialize_to matrix: [foo: 'foo'] }
+      let(:value) { { jobs: [foo: 'foo'] } }
+      it { should serialize_to jobs: [foo: 'foo'] }
     end
   end
 

--- a/spec/travis/yml/doc/accept/schema/env_spec.rb
+++ b/spec/travis/yml/doc/accept/schema/env_spec.rb
@@ -1,7 +1,7 @@
-describe Travis::Yml::Doc::Schema, 'matrix' do
+describe Travis::Yml::Doc::Schema, 'jobs' do
   subject { schema.matches?(build_value(value)) }
 
-  describe 'env with a map matrix: str' do
+  describe 'env with a map jobs: str' do
     let(:schema) { Travis::Yml.expand['env'] }
     let(:value)  { 'foo' }
     it { should be true }
@@ -13,8 +13,8 @@ describe Travis::Yml::Doc::Schema, 'matrix' do
     it { should be true }
   end
 
-  describe 'env.matrix with a secure' do
-    let(:schema) { Travis::Yml.expand['env'][0]['matrix'] }
+  describe 'env.jobs with a secure' do
+    let(:schema) { Travis::Yml.expand['env'][0]['jobs'] }
     let(:value)  { { secure: 'foo' } }
     it { should be true }
   end

--- a/spec/travis/yml/doc/accept/schema_spec.rb
+++ b/spec/travis/yml/doc/accept/schema_spec.rb
@@ -26,7 +26,7 @@ describe Travis::Yml::Doc::Schema do
 
   describe 'key_aliases' do
     subject { schema.key_aliases }
-    it { should include 'jobs' => 'matrix' }
+    it { should include 'matrix' => 'jobs' }
   end
 
   # describe 'env.matrix' do

--- a/spec/travis/yml/doc/changes/key_spec.rb
+++ b/spec/travis/yml/doc/changes/key_spec.rb
@@ -373,7 +373,7 @@ describe Travis::Yml::Doc::Change::Key do
     ]
     pairs.each do |(key, other)|
       describe "corrects they key #{key} to #{other}" do
-        let(:schema) { Travis::Yml.expand.map['matrix'][0] }
+        let(:schema) { Travis::Yml.expand.map['jobs'][0] }
         let(:key) { key }
         it { should eq other }
       end

--- a/spec/travis/yml/docs/examples_spec.rb
+++ b/spec/travis/yml/docs/examples_spec.rb
@@ -72,7 +72,7 @@ describe Travis::Yml::Docs::Examples do
 
     it do
       should eq [
-        { env: { global: [{ FOO: 'foo' }], matrix: [{ FOO: 'foo' }] } },
+        { env: { global: [{ FOO: 'foo' }], jobs: [{ FOO: 'foo' }] } },
         { env: [{ FOO: 'foo' }] },
         { env: [{ secure: 'encrypted string' }] },
         { env: ['FOO=foo'] },

--- a/spec/travis/yml/matrix_spec.rb
+++ b/spec/travis/yml/matrix_spec.rb
@@ -27,7 +27,7 @@ describe Travis::Yml, 'matrix' do
   describe 'matrix (1 from include, redundant expand key at root)' do
     yaml %(
       os: linux
-      matrix:
+      jobs:
         include:
           - os: osx
             env: FOO=foo
@@ -43,7 +43,7 @@ describe Travis::Yml, 'matrix' do
       os:
       - linux
       - osx
-      matrix:
+      jobs:
         include:
           - env: FOO=foo
     )
@@ -58,7 +58,7 @@ describe Travis::Yml, 'matrix' do
   describe 'matrix (1 with non-expand key at root)' do
     yaml %(
     language: rust
-    matrix:
+    jobs:
       include:
         env: FOO=foo
     )
@@ -86,7 +86,7 @@ describe Travis::Yml, 'matrix' do
   describe 'matrix (3)' do
     yaml %(
       env:
-        matrix:
+        jobs:
         - FOO=foo
         - BAR=bar
         - BAZ=baz
@@ -107,10 +107,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'env.matrix strs' do
+  describe 'env.jobs strs' do
     yaml %(
       env:
-        matrix:
+        jobs:
         - FOO=foo BAR=bar
         - BAZ=baz
     )
@@ -121,10 +121,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'env.matrix hashes' do
+  describe 'env.jobs hashes' do
     yaml %(
       env:
-        matrix:
+        jobs:
         - FOO: foo
         - BAR: bar
     )
@@ -135,10 +135,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'env.matrix one hash' do
+  describe 'env.jobs one hash' do
     yaml %(
       env:
-        matrix:
+        jobs:
           FOO: foo
           BAR: bar
     )
@@ -148,10 +148,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'env.matrix and env.global' do
+  describe 'env.jobs and env.global' do
     yaml %(
       env:
-        matrix:
+        jobs:
           - FOO: foo
           - BAR: bar
         global:
@@ -199,14 +199,14 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix include' do
+  describe 'jobs include' do
     yaml %(
       env:
-        matrix: FOO=foo
+        jobs: FOO=foo
       rvm:
       - 2.2
       - 2.3
-      matrix:
+      jobs:
         include:
           - env: BAR=bar
             rvm: 2.4
@@ -219,10 +219,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix include inheriting a global matrix key' do
+  describe 'jobs include inheriting a global matrix key' do
     yaml %(
       rvm: 2.4
-      matrix:
+      jobs:
         include:
           - rvm: 2.2
           - name: str
@@ -234,10 +234,10 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix include inheriting not env' do
+  describe 'jobs include inheriting not env' do
     yaml %(
       env: FOO=foo
-      matrix:
+      jobs:
         include:
           - name: one
           - name: two
@@ -249,11 +249,11 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix include inheriting env' do
+  describe 'jobs include inheriting env' do
     yaml %(
       env:
         global: FOO=foo
-      matrix:
+      jobs:
         include:
           - name: one
           - name: two
@@ -265,13 +265,13 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix include duplicate' do
+  describe 'jobs include duplicate' do
     yaml %(
       env:
-        matrix: FOO=foo
+        jobs: FOO=foo
       rvm:
       - 2.2
-      matrix:
+      jobs:
         include:
           - env: FOO=foo
             rvm: 2.2
@@ -282,16 +282,16 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix exclude (1)' do
+  describe 'jobs exclude (1)' do
     yaml %(
       env:
-        matrix:
+        jobs:
         - FOO=foo
         - BAR=bar
       rvm:
       - 2.2
       - 2.3
-      matrix:
+      jobs:
         exclude:
           - env: BAR=bar
             rvm: 2.3
@@ -304,11 +304,11 @@ describe Travis::Yml, 'matrix' do
     ]
   end
 
-  describe 'matrix exclude (2)' do
+  describe 'jobs exclude (2)' do
     yaml %(
       scala: 2.11.8
       jdk: oraclejdk8
-      matrix:
+      jobs:
         exclude:
         - scala: 2.11.8
           jdk: oraclejdk8
@@ -323,7 +323,7 @@ describe Travis::Yml, 'matrix' do
       rvm:
       - 2.2
       - 2.3
-      matrix:
+      jobs:
         include:
         - rvm: 1.8.7
           env: FOO=foo
@@ -339,7 +339,7 @@ describe Travis::Yml, 'matrix' do
   describe 'include as hash' do
     yaml %(
       dist: trusty
-      matrix:
+      jobs:
         include:
           env: FOO=foo
     )

--- a/spec/travis/yml/schema/def/env_spec.rb
+++ b/spec/travis/yml/schema/def/env_spec.rb
@@ -17,11 +17,14 @@ describe Travis::Yml::Schema::Def::Env do
             properties: {
               global: {
                 '$ref': '#/definitions/type/env_vars',
-                summary: 'Global environment variables to be defined on all jobs'
+                summary: instance_of(String),
               },
-              matrix: {
+              jobs: {
                 '$ref': '#/definitions/type/env_vars',
-                summary: 'Environment variables that expand the build matrix (creating one job per entry)',
+                summary: instance_of(String),
+                aliases: [
+                  :matrix
+                ],
                 flags: [
                   :expand
                 ]
@@ -30,7 +33,7 @@ describe Travis::Yml::Schema::Def::Env do
             additionalProperties: false,
             normal: true,
             prefix: {
-              key: :matrix
+              key: :jobs
             },
           },
           {
@@ -84,7 +87,7 @@ describe Travis::Yml::Schema::Def::Env do
               FOO: 'foo'
             },
             patternProperties: {
-              '^(?!global|matrix)': {
+              '^(?!global|jobs|matrix)': {
                 anyOf: [
                   {
                     type: :string

--- a/spec/travis/yml/schema/def/jobs_spec.rb
+++ b/spec/travis/yml/schema/def/jobs_spec.rb
@@ -1,29 +1,30 @@
-describe Travis::Yml::Schema::Def::Matrix do
-  describe 'matrix' do
-    subject { Travis::Yml.schema[:definitions][:type][:matrix] }
+describe Travis::Yml::Schema::Def::Jobs do
+  describe 'jobs' do
+    subject { Travis::Yml.schema[:definitions][:type][:jobs] }
 
     # it { puts JSON.pretty_generate(subject) }
 
     it do
       should include(
-        '$id': :matrix,
-        title: 'Matrix',
+        '$id': :jobs,
+        title: 'Job Matrix',
         summary: 'Build matrix definitions',
+        see: instance_of(Hash),
         normal: true,
         anyOf: [
           {
             type: :object,
             properties: {
               include: {
-                '$ref': '#/definitions/type/matrix_entries',
+                '$ref': '#/definitions/type/jobs_entries',
                 summary: instance_of(String)
               },
               exclude: {
-                '$ref': '#/definitions/type/matrix_entries',
+                '$ref': '#/definitions/type/jobs_entries',
                 summary: instance_of(String)
               },
               allow_failures: {
-                '$ref': '#/definitions/type/matrix_entries',
+                '$ref': '#/definitions/type/jobs_entries',
                 summary: instance_of(String),
                 aliases: [
                   :allowed_failures
@@ -40,7 +41,7 @@ describe Travis::Yml::Schema::Def::Matrix do
             additionalProperties: false,
             normal: true,
             aliases: [
-              :jobs
+              :matrix
             ],
             prefix: {
               key: :include
@@ -48,40 +49,40 @@ describe Travis::Yml::Schema::Def::Matrix do
             see: instance_of(Hash),
           },
           {
-            '$ref': '#/definitions/type/matrix_entries'
+            '$ref': '#/definitions/type/jobs_entries'
           }
         ]
       )
     end
   end
 
-  describe 'matrix_entries' do
-    subject { Travis::Yml.schema[:definitions][:type][:matrix_entries] }
+  describe 'jobs_entries' do
+    subject { Travis::Yml.schema[:definitions][:type][:jobs_entries] }
 
     # it { puts JSON.pretty_generate(subject) }
 
     it do
       should eq(
-        '$id': :matrix_entries,
-        title: 'Matrix Entries',
+        '$id': :jobs_entries,
+        title: 'Job Matrix Entries',
         anyOf: [
           {
             type: :array,
             items: {
-              '$ref': '#/definitions/type/matrix_entry',
+              '$ref': '#/definitions/type/jobs_entry',
             },
             normal: true,
           },
           {
-            '$ref': '#/definitions/type/matrix_entry',
+            '$ref': '#/definitions/type/jobs_entry',
           }
         ]
       )
     end
   end
 
-  describe 'matrix_entry' do
-    subject { Travis::Yml.schema[:definitions][:type][:matrix_entry][:allOf][0][:properties] }
+  describe 'jobs_entry' do
+    subject { Travis::Yml.schema[:definitions][:type][:jobs_entry][:allOf][0][:properties] }
 
     # it { puts JSON.pretty_generate(subject) }
 

--- a/spec/travis/yml/schema/def/root_spec.rb
+++ b/spec/travis/yml/schema/def/root_spec.rb
@@ -108,11 +108,11 @@ describe Travis::Yml::Schema::Def::Root do
         imports
         jdks
         job
+        jobs
+        jobs_entries
+        jobs_entry
         language
         languages
-        matrix
-        matrix_entries
-        matrix_entry
         notifications
         os
         oss
@@ -281,8 +281,8 @@ describe Travis::Yml::Schema::Def::Root do
           env
           filter_secrets
           import
+          jobs
           language
-          matrix
           notifications
           os
           stack
@@ -300,7 +300,7 @@ describe Travis::Yml::Schema::Def::Root do
       it { should include env:            { '$ref': '#/definitions/type/env' } }
       it { should include import:         { '$ref': '#/definitions/type/imports' } }
       # it { should include language:       { '$ref': '#/definitions/type/language' } }
-      it { should include matrix:         { '$ref': '#/definitions/type/matrix', aliases: [:jobs] } }
+      it { should include jobs:           { '$ref': '#/definitions/type/jobs', aliases: [:matrix] } }
       it { should include notifications:  { '$ref': '#/definitions/type/notifications' } }
       it { should include os:             { '$ref': '#/definitions/type/oss', flags: [:expand] } }
       it { should include stack:          { '$ref': '#/definitions/type/stack' } }

--- a/spec/travis/yml/web/v1_spec.rb
+++ b/spec/travis/yml/web/v1_spec.rb
@@ -183,7 +183,7 @@ describe Travis::Yml::Web::V1 do
             '2.6.2'
           ],
           'env' => {
-            'matrix' => [
+            'jobs' => [
               'API' => 'true',
               'FOO' => '1'
             ]
@@ -229,7 +229,7 @@ describe Travis::Yml::Web::V1 do
             '2.6.2'
           ],
           'env' => {
-            'matrix' => [
+            'jobs' => [
               'API' => 'true',
               'FOO' => '1',
               'TRAVIS_YML' => 'true',

--- a/spec/travis/yml_spec.rb
+++ b/spec/travis/yml_spec.rb
@@ -34,8 +34,8 @@ describe Travis::Yml do
         haxe
         hhvm
         jdk
+        jobs
         julia
-        matrix
         mono
         nix
         node_js

--- a/spec/travis/yml_spec.rb
+++ b/spec/travis/yml_spec.rb
@@ -84,8 +84,8 @@ describe Travis::Yml do
       it { expect(node.keys).to include 'addons' }
     end
 
-    describe 'matrix_entry' do
-      let(:node) { schema.map['matrix'][0]['include'][0].schema }
+    describe 'jobs_entry' do
+      let(:node) { schema.map['jobs'][0]['include'][0].schema }
       it { expect(node.keys).to include 'language' }
       it { expect(node.keys).to include 'rvm' }
       it { expect(node.keys).to include 'addons' }


### PR DESCRIPTION
* switches the alias for `jobs` and `matrix`, making `jobs` the new standard key
* allows `env.jobs` as the new standard key, and makes `env.matrix` an alias

![image](https://user-images.githubusercontent.com/2208/66853978-c61aac80-ef80-11e9-932b-56a265a7b00a.png)

![image](https://user-images.githubusercontent.com/2208/66854011-d3379b80-ef80-11e9-8e3f-044f79cf459e.png)

![image](https://user-images.githubusercontent.com/2208/66854056-e480a800-ef80-11e9-8911-7e03b6da6a86.png)

![image](https://user-images.githubusercontent.com/2208/66854084-ed717980-ef80-11e9-8be0-e5d9cca5cb34.png)

