### PR TITLE
allow enums on anys

### DIFF
--- a/lib/travis/yml/doc/helper/cast.rb
+++ b/lib/travis/yml/doc/helper/cast.rb
@@ -9,8 +9,8 @@ module Travis
         FALSES  = ['false', 'off', 'no', 'disabled', 'not required']
         BOOLS   = TRUES + FALSES
 
-        TRUE    = /(#{TRUES.join('|')})/
-        FALSE   = /(#{FALSES.join('|')})/
+        TRUE    = /^(#{TRUES.join('|')})$/
+        FALSE   = /^(#{FALSES.join('|')})$/
 
         def apply
           send(:"to_#{type}", value)

--- a/lib/travis/yml/schema/def/deploy/npm.rb
+++ b/lib/travis/yml/schema/def/deploy/npm.rb
@@ -10,7 +10,7 @@ module Travis
             def define
               map :email,       to: :secure, strict: false
               map :api_token,   to: :secure, alias: :api_key
-              map :access,      to: :str, enum: %w(public private)
+              map :access,      to: :str, values: %w(public private)
               map :registry,    to: :str
               map :src,         to: :str
               map :tag,         to: :str

--- a/lib/travis/yml/schema/def/git.rb
+++ b/lib/travis/yml/schema/def/git.rb
@@ -25,7 +25,7 @@ module Travis
             map :submodules_depth, to: :num, summary: 'Number of commits to fetch for submodules'
             map :lfs_skip_smudge,  to: :bool, summary: 'Skip fetching the git-lfs files during the initial git clone'
             map :sparse_checkout,  to: :str, summary: 'Populate the working directory sparsely'
-            map :autocrlf,         to: :str, values: [:true, :false, :input], summary: 'Specify handling of line endings when cloning repository'
+            map :autocrlf,         to: [:bool, :str], values: [true, false, 'input'], summary: 'Specify handling of line endings when cloning repository'
 
             export
           end

--- a/lib/travis/yml/schema/type/group.rb
+++ b/lib/travis/yml/schema/type/group.rb
@@ -25,6 +25,10 @@ module Travis
             self.types.concat(types)
           end
 
+          def values(value)
+            types.each { |type| type.value(*value) }
+          end
+
           def expand_keys
             super + types.map(&:expand_keys).flatten
           end

--- a/lib/travis/yml/schema/type/node.rb
+++ b/lib/travis/yml/schema/type/node.rb
@@ -20,7 +20,7 @@ module Travis
 
           class << self
             def build(type, attrs = {})
-              return build(:any, types: type) if type.is_a?(Array)
+              return build(:any, attrs.merge(types: type)) if type.is_a?(Array)
               caching(resolve(type), attrs) do |type|
                 node = type.new(self, only(attrs, :types))
                 node = Form.apply(node)
@@ -118,6 +118,7 @@ module Travis
           REMAP = {
             alias: :aliases,
             eg: :example,
+            enum: :value,
           }
 
           def assign(attrs)

--- a/lib/travis/yml/schema/type/scalar.rb
+++ b/lib/travis/yml/schema/type/scalar.rb
@@ -28,6 +28,7 @@ module Travis
           def value(*objs)
             objs = objs.flatten
             opts = objs.last.is_a?(Hash) ? objs.pop : {}
+            # objs = objs.select { |obj| matches?(obj) }
             objs = objs.map { |obj| { value: obj }.merge(opts) }
 
             attrs[:enum] ||= []

--- a/lib/travis/yml/schema/type/scalar.rb
+++ b/lib/travis/yml/schema/type/scalar.rb
@@ -8,6 +8,10 @@ module Travis
         class Scalar < Node
           opts %i(defaults enum strict values)
 
+          def matches?(*)
+            true
+          end
+
           def default(value, opts = {})
             value = value.to_s if str?
             value = { value: value }.merge(opts)
@@ -28,7 +32,7 @@ module Travis
           def value(*objs)
             objs = objs.flatten
             opts = objs.last.is_a?(Hash) ? objs.pop : {}
-            # objs = objs.select { |obj| matches?(obj) }
+            objs = objs.select { |obj| matches?(obj) }
             objs = objs.map { |obj| { value: obj }.merge(opts) }
 
             attrs[:enum] ||= []
@@ -72,6 +76,10 @@ module Travis
           def type
             :bool
           end
+
+          def matches?(obj)
+            obj.is_a?(TrueClass) || obj.is_a?(FalseClass)
+          end
         end
 
         class Num < Scalar
@@ -79,6 +87,10 @@ module Travis
 
           def type
             :num
+          end
+
+          def matches?(obj)
+            obj.is_a?(Numeric)
           end
         end
 
@@ -89,6 +101,10 @@ module Travis
 
           def type
             :str
+          end
+
+          def matches?(obj)
+            obj.is_a?(String) || obj.is_a?(Symbol)
           end
 
           def downcase(*)

--- a/schema.json
+++ b/schema.json
@@ -681,11 +681,23 @@
             "summary": "Populate the working directory sparsely"
           },
           "autocrlf": {
-            "type": "string",
-            "enum": [
-              "true",
-              "false",
-              "input"
+            "anyOf": [
+              {
+                "type": "boolean",
+                "enum": [
+                  true,
+                  false,
+                  "input"
+                ]
+              },
+              {
+                "type": "string",
+                "enum": [
+                  true,
+                  false,
+                  "input"
+                ]
+              }
             ],
             "summary": "Specify handling of line endings when cloning repository"
           }
@@ -4933,7 +4945,11 @@
                 ]
               },
               "access": {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "public",
+                  "private"
+                ]
               },
               "registry": {
                 "type": "string"

--- a/schema.json
+++ b/schema.json
@@ -686,15 +686,12 @@
                 "type": "boolean",
                 "enum": [
                   true,
-                  false,
-                  "input"
+                  false
                 ]
               },
               {
                 "type": "string",
                 "enum": [
-                  true,
-                  false,
                   "input"
                 ]
               }

--- a/spec/travis/yml/accept/git_spec.rb
+++ b/spec/travis/yml/accept/git_spec.rb
@@ -95,7 +95,8 @@ describe Travis::Yml, 'git' do
         git:
           autocrlf: true
       )
-      it { should serialize_to git: { autocrlf: 'true' } }
+      let(:value) { { git: { autocrlf: true } } }
+      it { should serialize_to git: { autocrlf: true } }
       it { should_not have_msg }
     end
 
@@ -104,7 +105,8 @@ describe Travis::Yml, 'git' do
         git:
           autocrlf: false
       )
-      it { should serialize_to git: { autocrlf: 'false' } }
+      let(:value) { { git: { autocrlf: false } } }
+      it { should serialize_to git: { autocrlf: false } }
       it { should_not have_msg }
     end
 
@@ -113,6 +115,7 @@ describe Travis::Yml, 'git' do
         git:
           autocrlf: input
       )
+      let(:value) { { git: { autocrlf: 'input' } } }
       it { should serialize_to git: { autocrlf: 'input' } }
       it { should_not have_msg }
     end
@@ -122,9 +125,9 @@ describe Travis::Yml, 'git' do
         git:
           autocrlf: invalid
       )
+      let(:value) { { git: { autocrlf: 'invalid' } } }
       it { should serialize_to git: { autocrlf: 'invalid' } }
       it { should have_msg [:error, :'git.autocrlf', :unknown_value, value: 'invalid'] }
     end
-
   end
 end

--- a/spec/travis/yml/accept/jobs_spec.rb
+++ b/spec/travis/yml/accept/jobs_spec.rb
@@ -486,9 +486,9 @@ describe Travis::Yml, 'jobs' do
               #{key}:
                 env:
                   - FOO=foo
-                  - BAR=bar
+                  - FOO=bar
           )
-          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo' }, { BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo' }, { FOO: 'bar' }]] } }
           it { should_not have_msg }
         end
 
@@ -498,9 +498,9 @@ describe Travis::Yml, 'jobs' do
               #{key}:
                 env:
                   FOO: foo
-                  BAR: bar
+                  FOO: bar
           )
-          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo', BAR: 'bar' }]] } }
+          it { should serialize_to jobs: { key => [env: [{ FOO: 'foo', FOO: 'bar' }]] } }
           it { should_not have_msg }
         end
 

--- a/spec/travis/yml/doc/helper/cast_spec.rb
+++ b/spec/travis/yml/doc/helper/cast_spec.rb
@@ -78,19 +78,19 @@ describe Travis::Yml::Doc::Cast do
         it { expect(cast.apply).to eq 'foo' }
       end
 
-      %w(ture tru true# true/ .true true;).each do |str|
-        describe str do
-          let(:value) { str }
-          it { expect(cast.apply).to be true }
-        end
-      end
-
-      %w(fakse fals false, false` falsedc flase).each do |str|
-        describe str do
-          let(:value) { str }
-          it { expect(cast.apply).to be false }
-        end
-      end
+      # %w(ture tru true# true/ .true true;).each do |str|
+      #   describe str do
+      #     let(:value) { str }
+      #     it { expect(cast.apply).to be true }
+      #   end
+      # end
+      #
+      # %w(fakse fals false, false` falsedc flase).each do |str|
+      #   describe str do
+      #     let(:value) { str }
+      #     it { expect(cast.apply).to be false }
+      #   end
+      # end
     end
   end
 

--- a/spec/travis/yml/doc/helper/cast_spec.rb
+++ b/spec/travis/yml/doc/helper/cast_spec.rb
@@ -73,24 +73,51 @@ describe Travis::Yml::Doc::Cast do
         it { expect(cast.apply).to be true }
       end
 
+      describe 'unknown' do
+        let(:value) { 'unknown' }
+        it { expect(cast.apply).to eq 'unknown' }
+      end
+
       describe 'any string' do
         let(:value) { 'foo' }
         it { expect(cast.apply).to eq 'foo' }
       end
 
-      # %w(ture tru true# true/ .true true;).each do |str|
-      #   describe str do
-      #     let(:value) { str }
-      #     it { expect(cast.apply).to be true }
-      #   end
-      # end
-      #
-      # %w(fakse fals false, false` falsedc flase).each do |str|
-      #   describe str do
-      #     let(:value) { str }
-      #     it { expect(cast.apply).to be false }
-      #   end
-      # end
+      %w(true# true/ .true true;).each do |str|
+        describe str do
+          let(:value) { str }
+          before { cast.apply }
+          it { expect(cast.apply).to be true }
+          it { expect(cast.msgs).to eq [[:clean_value, original: str, value: true]] }
+        end
+      end
+
+      %w(ture tru).each do |str|
+        describe str do
+          let(:value) { str }
+          before { cast.apply }
+          it { expect(cast.apply).to be true }
+          it { expect(cast.msgs).to eq [[:find_value, original: str, value: true]] }
+        end
+      end
+
+      %w(fakse fals falsedc flase).each do |str|
+        describe str do
+          let(:value) { str }
+          before { cast.apply }
+          it { expect(cast.apply).to be false }
+          it { expect(cast.msgs).to eq [[:find_value, original: str, value: false]] }
+        end
+
+      %w(false, false`).each do |str|
+        describe str do
+          let(:value) { str }
+          before { cast.apply }
+          it { expect(cast.apply).to be false }
+          it { expect(cast.msgs).to eq [[:clean_value, original: str, value: false]] }
+        end
+      end
+      end
     end
   end
 

--- a/spec/travis/yml/parts/merge_spec.rb
+++ b/spec/travis/yml/parts/merge_spec.rb
@@ -183,7 +183,7 @@ describe Travis::Yml::Parts::Merge do
   end
 
   describe 'merge mode and merge tags' do
-    let(:parts) { [part(one), part(two, nil, :deep_merge_append), part(three, nil, :deep_merge)] }
+    let(:parts) { [part(one), part(two, nil, :deep_merge), part(three)] }
 
     let(:one) do
       <<~yml

--- a/spec/travis/yml/schema/def/deploy/npm_spec.rb
+++ b/spec/travis/yml/schema/def/deploy/npm_spec.rb
@@ -25,7 +25,11 @@ describe Travis::Yml::Schema::Def::Deploy::Npm do
                 ]
               },
               access: {
-                type: :string
+                type: :string,
+                enum: [
+                  'public',
+                  'private'
+                ]
               },
               src: {
                 type: :string

--- a/spec/travis/yml/schema/def/git_spec.rb
+++ b/spec/travis/yml/schema/def/git_spec.rb
@@ -13,11 +13,23 @@ describe Travis::Yml::Schema::Def::Git do
       type: :object,
       properties: {
         autocrlf: {
-          type: :string,
-          enum: [
-            'true',
-            'false',
-            'input'
+          anyOf: [
+            {
+              type: :boolean,
+              enum: [
+                true,
+                false,
+                'input'
+              ]
+            },
+            {
+              type: :string,
+              enum: [
+                true,
+                false,
+                'input'
+              ]
+            }
           ],
           summary: instance_of(String),
         },

--- a/spec/travis/yml/schema/def/git_spec.rb
+++ b/spec/travis/yml/schema/def/git_spec.rb
@@ -18,15 +18,12 @@ describe Travis::Yml::Schema::Def::Git do
               type: :boolean,
               enum: [
                 true,
-                false,
-                'input'
+                false
               ]
             },
             {
               type: :string,
               enum: [
-                true,
-                false,
                 'input'
               ]
             }


### PR DESCRIPTION
This allows mapping several types as enums:

```
map :autocrlf, to: [:bool, :str], enum: [true, false, 'input']
```

It also fixes a bug where the `cast` helper would match `unknown` as `no` and thus return `false`.