### PR TITLE
Add i386 (for 32-bit binaries) + alias x64

### DIFF
--- a/lib/travis/yml/schema/def/arch.rb
+++ b/lib/travis/yml/schema/def/arch.rb
@@ -43,6 +43,7 @@ module Travis
             value :"arm64-graviton2"
             value :ppc64le, alias: %i(power ppc ppc64)
             value :i386
+            value :i386, alias: %i(x86)
             value :s390x
 
             export

--- a/lib/travis/yml/schema/def/arch.rb
+++ b/lib/travis/yml/schema/def/arch.rb
@@ -38,10 +38,11 @@ module Travis
             downcase
 
             supports :only, os: :linux
-            value :amd64, alias: :x86_64
+            value :amd64, alias: %i(x86_64 x64)
             value :arm64
             value :"arm64-graviton2"
             value :ppc64le, alias: %i(power ppc ppc64)
+            value :i386
             value :s390x
 
             export

--- a/schema.json
+++ b/schema.json
@@ -273,12 +273,14 @@
           "arm64",
           "arm64-graviton2",
           "ppc64le",
+          "i386",
           "s390x"
         ],
         "values": {
           "amd64": {
             "aliases": [
-              "x86_64"
+              "x86_64",
+              "x64"
             ]
           },
           "ppc64le": {
@@ -286,6 +288,11 @@
               "power",
               "ppc",
               "ppc64"
+            ]
+          },
+          "i386": {
+            "aliases": [
+              "x86"
             ]
           }
         }

--- a/spec/travis/yml/schema/def/arch_spec.rb
+++ b/spec/travis/yml/schema/def/arch_spec.rb
@@ -58,6 +58,11 @@ describe Travis::Yml::Schema::Def::Archs do
               'ppc',
               'ppc64'
             ]
+          },
+          i386: {
+            aliases: [
+              'x86'
+            ]
           }
         },
         only: {

--- a/spec/travis/yml/schema/def/arch_spec.rb
+++ b/spec/travis/yml/schema/def/arch_spec.rb
@@ -41,13 +41,15 @@ describe Travis::Yml::Schema::Def::Archs do
           'arm64',
           'arm64-graviton2',
           'ppc64le',
-          's390x'
+          'i386',
+          's390x',
         ],
         downcase: true,
         values: {
           amd64: {
             aliases: [
-              'x86_64'
+              'x86_64',
+              'x64',
             ]
           },
           ppc64le: {


### PR DESCRIPTION
Currently, we silently support `arch: x64` for `language: julia`, and this PR formalizes this.

In addition, https://github.com/travis-ci/travis-build/pull/1818 proposes `arch: i386` for using 32-bit binaries (on AMD arch).