### PR TITLE
set stage names early

### DIFF
--- a/lib/travis/yml/matrix.rb
+++ b/lib/travis/yml/matrix.rb
@@ -98,7 +98,16 @@ module Travis
 
         def included
           return [] unless config.is_a?(Hash) && config[:jobs].is_a?(Hash)
-          [config[:jobs][:include] || []].flatten.select { |row| row.is_a?(Hash) }
+          rows = [config[:jobs][:include] || []].flatten.select { |row| row.is_a?(Hash) }
+          with_stages(rows)
+        end
+
+        def with_stages(rows)
+          rows.inject(nil) do |stage, row|
+            row[:stage] ||= stage if stage
+            row[:stage] || stage
+          end
+          rows
         end
 
         def excluded

--- a/spec/travis/yml/matrix_spec.rb
+++ b/spec/travis/yml/matrix_spec.rb
@@ -481,4 +481,25 @@ describe Travis::Yml, 'matrix' do
       { language: 'shell' }
     ]
   end
+
+  describe 'stages with matching env vars' do
+    yaml %(
+      env:
+        - ONE=one
+        - TWO=two
+
+      jobs:
+        include:
+          - stage: one
+            env: ONE=one
+          - env: TWO=two
+    )
+
+    expands_to [
+      { env: [ONE: 'one'] },
+      { env: [TWO: 'two'] },
+      { env: [ONE: 'one'], stage: 'one' },
+      { env: [TWO: 'two'], stage: 'one' },
+    ]
+  end
 end


### PR DESCRIPTION
this fixes removal of seemingly duplicate jobs that use implicit assignment of stage names