### PR TITLE
add sonarcloud.enabled

### DIFF
--- a/lib/travis/yml/schema/def/addon/sonarcloud.rb
+++ b/lib/travis/yml/schema/def/addon/sonarcloud.rb
@@ -13,11 +13,12 @@ module Travis
               summary 'Sonarcloud settings'
               see 'Using SonarCloud with Travis CI': 'https://docs.travis-ci.com/user/sonarcloud/'
 
+              map :enabled,      to: :bool
               map :organization, to: :str
               map :token,        to: :secure
 
-              map :github_token, to: :secure, deprecated: 'not supported any more'
-              map :branches,     to: :seq,    deprecated: 'not supported any more'
+              map :github_token, to: :secure, deprecated: 'setting a GitHub token is deprecated'
+              map :branches,     to: :seq,    deprecated: 'setting a branch is deprecated'
             end
           end
         end

--- a/schema.json
+++ b/schema.json
@@ -2544,6 +2544,9 @@
           {
             "type": "object",
             "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
               "organization": {
                 "type": "string"
               },
@@ -2552,11 +2555,11 @@
               },
               "github_token": {
                 "$ref": "#/definitions/type/secure",
-                "deprecated": "not supported any more"
+                "deprecated": "setting a GitHub token is deprecated"
               },
               "branches": {
                 "$ref": "#/definitions/type/strs",
-                "deprecated": "not supported any more"
+                "deprecated": "setting a branch is deprecated"
               }
             },
             "additionalProperties": false,

--- a/spec/integrate/configs_spec.rb
+++ b/spec/integrate/configs_spec.rb
@@ -176,8 +176,8 @@ describe Travis::Yml, configs: true do
   DEPRECATIONS = [
     { key: 'jwt', info: 'Discontinued as of April 17, 2018' },
     { key: 'sudo', info: 'The key `sudo` has no effect anymore.' },
-    { key: 'branches', info: 'not supported any more' },
-    { key: 'github_token', info: 'not supported any more' },
+    { key: 'branches', info: 'setting a branch is deprecated' },
+    { key: 'github_token', info: 'setting a GitHub token is deprecated' },
     { key: 'skip_cleanup', info: 'not supported in dpl v2, use cleanup' },
     { key: 'skip_upload_docs', info: 'use upload_docs: false' },
     { key: 'no_promote', info: 'use promote: false' },

--- a/spec/travis/yml/accept/addon/sonarcloud_spec.rb
+++ b/spec/travis/yml/accept/addon/sonarcloud_spec.rb
@@ -1,6 +1,25 @@
 describe Travis::Yml, 'addon: sonarcloud' do
   subject { described_class.apply(parse(yaml)) }
 
+  describe 'given true' do
+    yaml %(
+      addons:
+        sonarcloud: true
+    )
+    it { should serialize_to addons: { sonarcloud: { enabled: true } } }
+    it { should_not have_msg }
+  end
+
+  describe 'given enabled' do
+    yaml %(
+      addons:
+        sonarcloud:
+          enabled: true
+    )
+    it { should serialize_to addons: { sonarcloud: { enabled: true } } }
+    it { should_not have_msg }
+  end
+
   describe 'given organization' do
     yaml %(
       addons:
@@ -39,7 +58,7 @@ describe Travis::Yml, 'addon: sonarcloud' do
           branches: str
     )
     it { should serialize_to addons: { sonarcloud: { branches: ['str'] } } }
-    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'branches', info: 'not supported any more'] }
+    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'branches', info: 'setting a branch is deprecated'] }
     it { expect(msgs.size).to eq 1 }
   end
 
@@ -51,7 +70,7 @@ describe Travis::Yml, 'addon: sonarcloud' do
           - str
     )
     it { should serialize_to addons: { sonarcloud: { branches: ['str'] } } }
-    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'branches', info: 'not supported any more'] }
+    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'branches', info: 'setting a branch is deprecated'] }
     it { expect(msgs.size).to eq 1 }
   end
 
@@ -62,7 +81,7 @@ describe Travis::Yml, 'addon: sonarcloud' do
           github_token: str
     )
     it { should serialize_to addons: { sonarcloud: { github_token: 'str' } } }
-    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'github_token', info: 'not supported any more'] }
+    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'github_token', info: 'setting a GitHub token is deprecated'] }
     it { expect(msgs.size).to eq 1 }
   end
 
@@ -74,7 +93,7 @@ describe Travis::Yml, 'addon: sonarcloud' do
             secure: str
     )
     it { should serialize_to addons: { sonarcloud: { github_token: { secure: 'str' } } } }
-    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'github_token', info: 'not supported any more'] }
+    it { should have_msg [:warn, :'addons.sonarcloud', :deprecated_key, key: 'github_token', info: 'setting a GitHub token is deprecated'] }
     it { expect(msgs.size).to eq 1 }
   end
 end

--- a/spec/travis/yml/schema/def/addon/sonarcloud_spec.rb
+++ b/spec/travis/yml/schema/def/addon/sonarcloud_spec.rb
@@ -13,6 +13,9 @@ describe Travis::Yml::Schema::Def::Addon::Sonarcloud do
         {
           type: :object,
           properties: {
+            enabled: {
+              type: :boolean
+            },
             organization: {
               type: :string
             },
@@ -21,11 +24,11 @@ describe Travis::Yml::Schema::Def::Addon::Sonarcloud do
             },
             github_token: {
               '$ref': '#/definitions/type/secure',
-              deprecated: 'not supported any more'
+              deprecated: 'setting a GitHub token is deprecated'
             },
             branches: {
               '$ref': '#/definitions/type/strs',
-              deprecated: 'not supported any more'
+              deprecated: 'setting a branch is deprecated'
             }
           },
           additionalProperties: false,


### PR DESCRIPTION
allows keeping the `sonarcloud` key even if no organization or token are given.