### PR TITLE
Remove `downcase` function for `group:` names

### DIFF
--- a/lib/travis/yml/schema/def/group.rb
+++ b/lib/travis/yml/schema/def/group.rb
@@ -10,7 +10,6 @@ module Travis
 
           def define
             summary 'Build environment group'
-            downcase
             internal
             export
           end

--- a/spec/travis/yml/schema/def/group_spec.rb
+++ b/spec/travis/yml/schema/def/group_spec.rb
@@ -9,7 +9,6 @@ describe Travis::Yml::Schema::Def::Group do
       title: 'Group',
       summary: 'Build environment group',
       type: :string,
-      downcase: true,
       flags: [:internal]
     )
   end


### PR DESCRIPTION
Build Config Validation converts all `group: XYZ` entries to `group: xyz`. This negatively affects some customers. 