### PR TITLE
Restrict ruby gem-update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ stages:
     if: commit_message =~ /ship:docker/ OR env(SHIP_DOCKER) = true
 
 before_install:
+  - gem install rubygems-update -v 3.4.22
   - gem update --silent --system 3.4.13
   - 'echo "gem: --no-document" >> ~/.gemrc' # Skip installing documentation
   # - gem install bundler -v $(awk '/BUNDLED WITH/{getline; print}' Gemfile.lock)


### PR DESCRIPTION
Restrict ruby gem-update to 3.4.22 because it still supports ruby 2.6